### PR TITLE
Persist workspace foundation data with Drizzle

### DIFF
--- a/apps/api/src/ai/ai-provider.factory.ts
+++ b/apps/api/src/ai/ai-provider.factory.ts
@@ -7,14 +7,14 @@ import { ProviderProfilesService } from "../provider-profiles/provider-profiles.
 export class AiProviderFactory {
   constructor(private readonly providerProfiles: ProviderProfilesService) {}
 
-  createLanguageModel(profileId: string): LanguageModelV1 {
-    const profile = this.providerProfiles.getStored(profileId);
+  async createLanguageModel(profileId: string): Promise<LanguageModelV1> {
+    const profile = await this.providerProfiles.getStored(profileId);
     if (!profile) {
       throw new NotFoundException("Provider profile not found");
     }
     const provider = createOpenAI({
       baseURL: profile.baseUrl,
-      apiKey: this.providerProfiles.getApiKey(profileId)
+      apiKey: await this.providerProfiles.getApiKey(profileId)
     });
     return provider(profile.defaultModel);
   }

--- a/apps/api/src/provider-profiles/provider-profiles.module.ts
+++ b/apps/api/src/provider-profiles/provider-profiles.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
+import { DbModule } from "../db/db.module";
 import { WorkspacesModule } from "../workspaces/workspaces.module";
 import { ProviderProfilesResolver } from "./provider-profiles.resolver";
 import { ProviderProfilesService } from "./provider-profiles.service";
 
 @Module({
-  imports: [WorkspacesModule],
+  imports: [DbModule, WorkspacesModule],
   providers: [ProviderProfilesService, ProviderProfilesResolver],
   exports: [ProviderProfilesService]
 })

--- a/apps/api/src/provider-profiles/provider-profiles.resolver.ts
+++ b/apps/api/src/provider-profiles/provider-profiles.resolver.ts
@@ -11,7 +11,7 @@ export class ProviderProfilesResolver {
   providerProfiles(
     @Args("workspaceId", { type: () => String }) workspaceId: string,
     @Context("req") req: { headers: Record<string, string | undefined> }
-  ): ProviderProfile[] {
+  ): Promise<ProviderProfile[]> {
     return this.providerProfileService.list(workspaceId, currentUserId(req));
   }
 
@@ -19,7 +19,7 @@ export class ProviderProfilesResolver {
   createProviderProfile(
     @Args("input", { type: () => ProviderProfileInput }) input: ProviderProfileInput,
     @Context("req") req: { headers: Record<string, string | undefined> }
-  ): ProviderProfile {
+  ): Promise<ProviderProfile> {
     return this.providerProfileService.create(input, currentUserId(req));
   }
 }

--- a/apps/api/src/provider-profiles/provider-profiles.service.ts
+++ b/apps/api/src/provider-profiles/provider-profiles.service.ts
@@ -1,9 +1,14 @@
 import { BadRequestException, Injectable, InternalServerErrorException } from "@nestjs/common";
+import { Inject } from "@nestjs/common";
 import { createCipheriv, createDecipheriv, createHash, randomBytes, randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
+import { DB } from "../db/db.module";
+import { providerProfiles } from "../db/schema";
+import { AppDb } from "../db/types";
 import { isoNow } from "../common/date";
 import { WorkspacesService } from "../workspaces/workspaces.service";
-import { ProviderProfile, ProviderProfileInput } from "./provider-profile.types";
+import { ProviderProfile, ProviderProfileInput, ProviderTypeGql } from "./provider-profile.types";
 
 const providerProfileInputSchema = z.object({
   workspaceId: z.string().uuid(),
@@ -22,61 +27,65 @@ type StoredProviderProfile = ProviderProfile & {
 
 @Injectable()
 export class ProviderProfilesService {
-  private readonly profiles = new Map<string, StoredProviderProfile>();
+  constructor(
+    private readonly workspaces: WorkspacesService,
+    @Inject(DB) private readonly db: AppDb
+  ) {}
 
-  constructor(private readonly workspaces: WorkspacesService) {}
-
-  create(input: ProviderProfileInput, userId: string): ProviderProfile {
-    this.assertWorkspaceMember(input.workspaceId, userId);
+  async create(input: ProviderProfileInput, userId: string): Promise<ProviderProfile> {
+    await this.assertWorkspaceMember(input.workspaceId, userId);
     providerProfileInputSchema.parse({
       ...input,
       providerType: "openai-compatible"
     });
-    const now = isoNow();
-    const profile: StoredProviderProfile = {
-      id: randomUUID(),
-      workspaceId: input.workspaceId,
-      displayName: input.displayName,
-      providerType: input.providerType,
-      baseUrl: input.baseUrl,
-      defaultModel: input.defaultModel,
-      capabilities: input.capabilities,
-      hasApiKey: true,
-      encryptedApiKey: this.encryptForStorage(input.apiKey),
-      createdAt: now,
-      updatedAt: now,
-      ...(input.defaultImageModel ? { defaultImageModel: input.defaultImageModel } : {})
-    };
-    this.profiles.set(profile.id, profile);
-    return this.redact(profile);
+    const [profile] = await this.db
+      .insert(providerProfiles)
+      .values({
+        workspaceId: input.workspaceId,
+        ownerId: userId,
+        displayName: input.displayName,
+        providerType: "openai-compatible",
+        baseUrl: input.baseUrl,
+        defaultModel: input.defaultModel,
+        defaultImageModel: input.defaultImageModel,
+        capabilities: input.capabilities,
+        encryptedApiKey: this.encryptForStorage(input.apiKey)
+      })
+      .returning();
+    if (!profile) {
+      throw new Error("Provider profile creation failed");
+    }
+    return this.toProviderProfile(profile);
   }
 
-  list(workspaceId: string, userId: string): ProviderProfile[] {
-    this.assertWorkspaceMember(workspaceId, userId);
-    return [...this.profiles.values()]
-      .filter((profile) => profile.workspaceId === workspaceId)
-      .map((profile) => this.redact(profile));
+  async list(workspaceId: string, userId: string): Promise<ProviderProfile[]> {
+    await this.assertWorkspaceMember(workspaceId, userId);
+    const rows = await this.db
+      .select()
+      .from(providerProfiles)
+      .where(eq(providerProfiles.workspaceId, workspaceId));
+    return rows.map((row) => this.toProviderProfile(row));
   }
 
-  getStored(id: string): StoredProviderProfile | undefined {
-    return this.profiles.get(id);
+  async getStored(id: string): Promise<StoredProviderProfile | undefined> {
+    const [profile] = await this.db
+      .select()
+      .from(providerProfiles)
+      .where(eq(providerProfiles.id, id))
+      .limit(1);
+    return profile ? this.toStoredProviderProfile(profile) : undefined;
   }
 
-  getApiKey(id: string): string {
-    const profile = this.profiles.get(id);
+  async getApiKey(id: string): Promise<string> {
+    const profile = await this.getStored(id);
     if (!profile) {
       throw new BadRequestException("Provider profile not found");
     }
     return this.decryptFromStorage(profile.encryptedApiKey);
   }
 
-  private redact(profile: StoredProviderProfile): ProviderProfile {
-    const { encryptedApiKey: _encryptedApiKey, ...view } = profile;
-    return view;
-  }
-
-  private assertWorkspaceMember(workspaceId: string, userId: string): void {
-    this.workspaces.assertMember(workspaceId, userId);
+  private async assertWorkspaceMember(workspaceId: string, userId: string): Promise<void> {
+    await this.workspaces.assertMember(workspaceId, userId);
   }
 
   private encryptForStorage(value: string): string {
@@ -105,5 +114,29 @@ export class ProviderProfilesService {
     const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(ivRaw, "base64url"));
     decipher.setAuthTag(Buffer.from(tagRaw, "base64url"));
     return Buffer.concat([decipher.update(Buffer.from(encryptedRaw, "base64url")), decipher.final()]).toString("utf8");
+  }
+
+  private toProviderProfile(row: typeof providerProfiles.$inferSelect): ProviderProfile {
+    return {
+      id: row.id,
+      workspaceId: row.workspaceId,
+      displayName: row.displayName,
+      providerType: ProviderTypeGql.OPENAI_COMPATIBLE,
+      baseUrl: row.baseUrl,
+      defaultModel: row.defaultModel,
+      capabilities: row.capabilities,
+      hasApiKey: true,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+      ...(row.defaultImageModel ? { defaultImageModel: row.defaultImageModel } : {}),
+      ...(row.verifiedAt ? { verifiedAt: row.verifiedAt.toISOString() } : {})
+    };
+  }
+
+  private toStoredProviderProfile(row: typeof providerProfiles.$inferSelect): StoredProviderProfile {
+    return {
+      ...this.toProviderProfile(row),
+      encryptedApiKey: row.encryptedApiKey
+    };
   }
 }

--- a/apps/api/src/provider-profiles/provider-profiles.service.ts
+++ b/apps/api/src/provider-profiles/provider-profiles.service.ts
@@ -25,8 +25,6 @@ type StoredProviderProfile = ProviderProfile & {
   encryptedApiKey: string;
 };
 
-const E2E_PROVIDER_SECRET_KEY = "local-e2e-provider-secret";
-
 @Injectable()
 export class ProviderProfilesService {
   constructor(
@@ -114,9 +112,6 @@ export class ProviderProfilesService {
     const secret = process.env.PROVIDER_SECRET_KEY?.trim();
     if (secret) {
       return secret;
-    }
-    if (process.env.ENABLE_E2E_PASSWORD_LOGIN === "true" && process.env.NODE_ENV !== "production") {
-      return E2E_PROVIDER_SECRET_KEY;
     }
     throw new InternalServerErrorException("PROVIDER_SECRET_KEY is required for persisted provider API keys");
   }

--- a/apps/api/src/provider-profiles/provider-profiles.service.ts
+++ b/apps/api/src/provider-profiles/provider-profiles.service.ts
@@ -25,6 +25,8 @@ type StoredProviderProfile = ProviderProfile & {
   encryptedApiKey: string;
 };
 
+const E2E_PROVIDER_SECRET_KEY = "local-e2e-provider-secret";
+
 @Injectable()
 export class ProviderProfilesService {
   constructor(
@@ -89,11 +91,7 @@ export class ProviderProfilesService {
   }
 
   private encryptForStorage(value: string): string {
-    const secret = process.env.PROVIDER_SECRET_KEY;
-    if (!secret && process.env.NODE_ENV === "production") {
-      throw new InternalServerErrorException("PROVIDER_SECRET_KEY is required in production");
-    }
-    const key = createHash("sha256").update(secret ?? "local-e2e-provider-secret").digest();
+    const key = createHash("sha256").update(this.providerSecretKey()).digest();
     const iv = randomBytes(12);
     const cipher = createCipheriv("aes-256-gcm", key, iv);
     const encrypted = Buffer.concat([cipher.update(value, "utf8"), cipher.final()]);
@@ -106,14 +104,21 @@ export class ProviderProfilesService {
     if (!ivRaw || !tagRaw || !encryptedRaw) {
       throw new InternalServerErrorException("Invalid encrypted provider key payload");
     }
-    const secret = process.env.PROVIDER_SECRET_KEY;
-    if (!secret && process.env.NODE_ENV === "production") {
-      throw new InternalServerErrorException("PROVIDER_SECRET_KEY is required in production");
-    }
-    const key = createHash("sha256").update(secret ?? "local-e2e-provider-secret").digest();
+    const key = createHash("sha256").update(this.providerSecretKey()).digest();
     const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(ivRaw, "base64url"));
     decipher.setAuthTag(Buffer.from(tagRaw, "base64url"));
     return Buffer.concat([decipher.update(Buffer.from(encryptedRaw, "base64url")), decipher.final()]).toString("utf8");
+  }
+
+  private providerSecretKey(): string {
+    const secret = process.env.PROVIDER_SECRET_KEY?.trim();
+    if (secret) {
+      return secret;
+    }
+    if (process.env.ENABLE_E2E_PASSWORD_LOGIN === "true" && process.env.NODE_ENV !== "production") {
+      return E2E_PROVIDER_SECRET_KEY;
+    }
+    throw new InternalServerErrorException("PROVIDER_SECRET_KEY is required for persisted provider API keys");
   }
 
   private toProviderProfile(row: typeof providerProfiles.$inferSelect): ProviderProfile {

--- a/apps/api/src/skills/skills.module.ts
+++ b/apps/api/src/skills/skills.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
+import { DbModule } from "../db/db.module";
 import { WorkspacesModule } from "../workspaces/workspaces.module";
 import { SkillsResolver } from "./skills.resolver";
 import { SkillsService } from "./skills.service";
 
 @Module({
-  imports: [WorkspacesModule],
+  imports: [DbModule, WorkspacesModule],
   providers: [SkillsService, SkillsResolver]
 })
 export class SkillsModule {}

--- a/apps/api/src/skills/skills.resolver.ts
+++ b/apps/api/src/skills/skills.resolver.ts
@@ -11,7 +11,7 @@ export class SkillsResolver {
   skills(
     @Args("workspaceId", { type: () => String }) workspaceId: string,
     @Context("req") req: { headers: Record<string, string | undefined> }
-  ): Skill[] {
+  ): Promise<Skill[]> {
     return this.skillService.list(workspaceId, currentUserId(req));
   }
 
@@ -19,7 +19,7 @@ export class SkillsResolver {
   uploadSkill(
     @Args("input", { type: () => SkillUploadInput }) input: SkillUploadInput,
     @Context("req") req: { headers: Record<string, string | undefined> }
-  ): SkillUploadResult {
+  ): Promise<SkillUploadResult> {
     return this.skillService.upload(input, currentUserId(req));
   }
 }

--- a/apps/api/src/skills/skills.service.ts
+++ b/apps/api/src/skills/skills.service.ts
@@ -1,51 +1,100 @@
 import { Injectable } from "@nestjs/common";
-import { randomUUID } from "node:crypto";
-import { isoNow } from "../common/date";
+import { Inject } from "@nestjs/common";
+import { eq } from "drizzle-orm";
+import { DB } from "../db/db.module";
+import { assets, skills, skillVersions } from "../db/schema";
+import { AppDb } from "../db/types";
 import { WorkspacesService } from "../workspaces/workspaces.service";
 import { parseSkillMd } from "./skill-md.parser";
 import { Skill, SkillUploadInput, SkillUploadResult, SkillVersion } from "./skill.types";
 
 @Injectable()
 export class SkillsService {
-  private readonly skills = new Map<string, Skill>();
-  private readonly versions = new Map<string, SkillVersion[]>();
+  constructor(
+    private readonly workspaces: WorkspacesService,
+    @Inject(DB) private readonly db: AppDb
+  ) {}
 
-  constructor(private readonly workspaces: WorkspacesService) {}
-
-  list(workspaceId: string, userId: string): Skill[] {
-    this.assertWorkspaceMember(workspaceId, userId);
-    return [...this.skills.values()].filter((skill) => skill.workspaceId === workspaceId);
+  async list(workspaceId: string, userId: string): Promise<Skill[]> {
+    await this.assertWorkspaceMember(workspaceId, userId);
+    const rows = await this.db.select().from(skills).where(eq(skills.workspaceId, workspaceId));
+    return rows.map((row) => this.toSkill(row));
   }
 
-  upload(input: SkillUploadInput, userId: string): SkillUploadResult {
-    this.assertWorkspaceMember(input.workspaceId, userId);
+  async upload(input: SkillUploadInput, userId: string): Promise<SkillUploadResult> {
+    await this.assertWorkspaceMember(input.workspaceId, userId);
     const parsed = parseSkillMd(input.skillMdContent);
-    const now = isoNow();
-    const skill: Skill = {
-      id: randomUUID(),
-      workspaceId: input.workspaceId,
-      name: parsed.name || "Invalid Skill",
-      slug: this.slugify(parsed.name || `invalid-${Date.now()}`),
-      status: "active",
-      createdAt: now,
-      updatedAt: now
+    const name = parsed.name || "Invalid Skill";
+    const result = await this.db.transaction(async (tx) => {
+      const [archiveAsset] = await tx
+        .insert(assets)
+        .values({
+          workspaceId: input.workspaceId,
+          ownerId: userId,
+          kind: "skill-archive",
+          mimeType: "text/markdown",
+          byteSize: Buffer.byteLength(input.skillMdContent),
+          sha256: input.archiveSha256,
+          storagePath: `skill-archives/${input.archiveSha256}`
+        })
+        .returning();
+      if (!archiveAsset) {
+        throw new Error("Skill archive asset creation failed");
+      }
+
+      const [skill] = await tx
+        .insert(skills)
+        .values({
+          workspaceId: input.workspaceId,
+          ownerId: userId,
+          name,
+          slug: `${this.slugify(name)}-${Date.now().toString(36)}`,
+          status: "active"
+        })
+        .returning();
+      if (!skill) {
+        throw new Error("Skill creation failed");
+      }
+
+      const metadata = {
+        name: parsed.name,
+        description: parsed.description,
+        ...(parsed.version ? { version: parsed.version } : {})
+      };
+      const [version] = await tx
+        .insert(skillVersions)
+        .values({
+          skillId: skill.id,
+          archiveAssetId: archiveAsset.id,
+          version: parsed.version,
+          metadata,
+          permissions: input.permissions,
+          validationStatus: parsed.errors.length === 0 ? "valid" : "invalid",
+          validationErrors: parsed.errors
+        })
+        .returning();
+      if (!version) {
+        throw new Error("Skill version creation failed");
+      }
+
+      const [updatedSkill] = await tx
+        .update(skills)
+        .set({ latestVersionId: version.id })
+        .where(eq(skills.id, skill.id))
+        .returning();
+      if (!updatedSkill) {
+        throw new Error("Skill latest version update failed");
+      }
+
+      return {
+        skill: updatedSkill,
+        version
+      };
+    });
+    return {
+      skill: this.toSkill(result.skill),
+      version: this.toSkillVersion(result.version)
     };
-    const version: SkillVersion = {
-      id: randomUUID(),
-      skillId: skill.id,
-      version: parsed.version,
-      name: parsed.name,
-      description: parsed.description,
-      permissions: input.permissions,
-      validationStatus: parsed.errors.length === 0 ? "valid" : "invalid",
-      validationErrors: parsed.errors,
-      createdAt: now
-    };
-    skill.latestVersionId = version.id;
-    this.skills.set(skill.id, skill);
-    this.versions.set(skill.id, [version]);
-    void input.archiveSha256;
-    return { skill, version };
   }
 
   private slugify(value: string): string {
@@ -56,7 +105,34 @@ export class SkillsService {
       .slice(0, 80);
   }
 
-  private assertWorkspaceMember(workspaceId: string, userId: string): void {
-    this.workspaces.assertMember(workspaceId, userId);
+  private async assertWorkspaceMember(workspaceId: string, userId: string): Promise<void> {
+    await this.workspaces.assertMember(workspaceId, userId);
+  }
+
+  private toSkill(row: typeof skills.$inferSelect): Skill {
+    return {
+      id: row.id,
+      workspaceId: row.workspaceId,
+      name: row.name,
+      slug: row.slug,
+      status: row.status,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+      ...(row.latestVersionId ? { latestVersionId: row.latestVersionId } : {})
+    };
+  }
+
+  private toSkillVersion(row: typeof skillVersions.$inferSelect): SkillVersion {
+    return {
+      id: row.id,
+      skillId: row.skillId,
+      version: row.version,
+      name: row.metadata.name,
+      description: row.metadata.description,
+      permissions: row.permissions,
+      validationStatus: row.validationStatus,
+      validationErrors: row.validationErrors,
+      createdAt: row.createdAt.toISOString()
+    };
   }
 }

--- a/apps/api/src/skills/skills.service.ts
+++ b/apps/api/src/skills/skills.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { Inject } from "@nestjs/common";
+import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { DB } from "../db/db.module";
 import { assets, skills, skillVersions } from "../db/schema";
@@ -48,7 +49,7 @@ export class SkillsService {
           workspaceId: input.workspaceId,
           ownerId: userId,
           name,
-          slug: `${this.slugify(name)}-${Date.now().toString(36)}`,
+          slug: `${this.slugify(name)}-${randomUUID().slice(0, 8)}`,
           status: "active"
         })
         .returning();
@@ -98,11 +99,12 @@ export class SkillsService {
   }
 
   private slugify(value: string): string {
-    return value
+    const slug = value
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-|-$/g, "")
       .slice(0, 80);
+    return slug || "skill";
   }
 
   private async assertWorkspaceMember(workspaceId: string, userId: string): Promise<void> {

--- a/apps/api/src/workspaces/workspaces.module.ts
+++ b/apps/api/src/workspaces/workspaces.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
+import { DbModule } from "../db/db.module";
 import { WorkspacesResolver } from "./workspaces.resolver";
 import { WorkspacesService } from "./workspaces.service";
 
 @Module({
+  imports: [DbModule],
   providers: [WorkspacesService, WorkspacesResolver],
   exports: [WorkspacesService]
 })
 export class WorkspacesModule {}
-

--- a/apps/api/src/workspaces/workspaces.resolver.ts
+++ b/apps/api/src/workspaces/workspaces.resolver.ts
@@ -8,18 +8,18 @@ export class WorkspacesResolver {
   constructor(private readonly workspaces: WorkspacesService) {}
 
   @Query(() => [Workspace])
-  workspacesForCurrentUser(@Context("req") req: { headers: Record<string, string | undefined> }): Workspace[] {
+  async workspacesForCurrentUser(@Context("req") req: { headers: Record<string, string | undefined> }): Promise<Workspace[]> {
     const userId = currentUserId(req);
-    this.workspaces.ensureWorkspaceForUser(userId);
+    await this.workspaces.ensureWorkspaceForUser(userId);
     return this.workspaces.listForUser(userId);
   }
 
   @Query(() => [WorkspaceMembership])
-  workspaceMembers(
+  async workspaceMembers(
     @Args("workspaceId", { type: () => String }) workspaceId: string,
     @Context("req") req: { headers: Record<string, string | undefined> }
-  ): WorkspaceMembership[] {
-    this.workspaces.assertMember(workspaceId, currentUserId(req));
+  ): Promise<WorkspaceMembership[]> {
+    await this.workspaces.assertMember(workspaceId, currentUserId(req));
     return this.workspaces.listMemberships(workspaceId);
   }
 
@@ -27,7 +27,7 @@ export class WorkspacesResolver {
   createWorkspace(
     @Args("name", { type: () => String }) name: string,
     @Context("req") req: { headers: Record<string, string | undefined> }
-  ): Workspace {
+  ): Promise<Workspace> {
     return this.workspaces.createWorkspace({ name, ownerId: currentUserId(req) });
   }
 }

--- a/apps/api/src/workspaces/workspaces.service.ts
+++ b/apps/api/src/workspaces/workspaces.service.ts
@@ -1,5 +1,6 @@
 import { ForbiddenException, Injectable } from "@nestjs/common";
 import { Inject } from "@nestjs/common";
+import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import { DB } from "../db/db.module";
 import { workspaceMemberships, workspaces, users } from "../db/schema";
@@ -12,7 +13,7 @@ export class WorkspacesService {
 
   async createWorkspace(input: { name: string; ownerId: string }): Promise<Workspace> {
     await this.ensureUser(input.ownerId);
-    const slug = `${this.slugify(input.name)}-${input.ownerId.slice(-6)}`;
+    const slug = `${this.slugify(input.name)}-${input.ownerId.slice(-6)}-${randomUUID().slice(0, 8)}`;
     const [workspace] = await this.db
       .insert(workspaces)
       .values({ name: input.name, slug })
@@ -111,10 +112,11 @@ export class WorkspacesService {
   }
 
   private slugify(value: string): string {
-    return value
+    const slug = value
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-|-$/g, "")
       .slice(0, 80);
+    return slug || "workspace";
   }
 }

--- a/apps/api/src/workspaces/workspaces.service.ts
+++ b/apps/api/src/workspaces/workspaces.service.ts
@@ -20,11 +20,7 @@ export class WorkspacesService {
     if (!workspace) {
       throw new Error("Workspace creation failed");
     }
-    await this.db.insert(workspaceMemberships).values({
-      workspaceId: workspace.id,
-      userId: input.ownerId,
-      role: "owner"
-    });
+    await this.ensureMembership(workspace.id, input.ownerId, "owner");
     return this.toWorkspace(workspace);
   }
 
@@ -71,7 +67,31 @@ export class WorkspacesService {
     if (existing) {
       return existing;
     }
-    return this.createWorkspace({ name: "Personal Workspace", ownerId: userId });
+
+    const slug = `personal-${userId}`;
+    const [inserted] = await this.db
+      .insert(workspaces)
+      .values({ name: "Personal Workspace", slug })
+      .onConflictDoNothing()
+      .returning();
+    const workspace = inserted ?? (await this.findBySlug(slug));
+    if (!workspace) {
+      throw new Error("Personal workspace creation failed");
+    }
+    await this.ensureMembership(workspace.id, userId, "owner");
+    return this.toWorkspace(workspace);
+  }
+
+  private async findBySlug(slug: string): Promise<typeof workspaces.$inferSelect | undefined> {
+    const [workspace] = await this.db.select().from(workspaces).where(eq(workspaces.slug, slug)).limit(1);
+    return workspace;
+  }
+
+  private async ensureMembership(workspaceId: string, userId: string, role: "owner"): Promise<void> {
+    await this.db
+      .insert(workspaceMemberships)
+      .values({ workspaceId, userId, role })
+      .onConflictDoNothing();
   }
 
   private async ensureUser(userId: string): Promise<void> {

--- a/apps/api/src/workspaces/workspaces.service.ts
+++ b/apps/api/src/workspaces/workspaces.service.ts
@@ -1,63 +1,93 @@
 import { ForbiddenException, Injectable } from "@nestjs/common";
-import { randomUUID } from "node:crypto";
-import { isoNow } from "../common/date";
+import { Inject } from "@nestjs/common";
+import { and, eq } from "drizzle-orm";
+import { DB } from "../db/db.module";
+import { workspaceMemberships, workspaces, users } from "../db/schema";
+import { AppDb } from "../db/types";
 import { Workspace, WorkspaceMembership } from "./workspace.types";
 
 @Injectable()
 export class WorkspacesService {
-  private readonly workspaces = new Map<string, Workspace>();
-  private readonly memberships = new Map<string, WorkspaceMembership[]>();
+  constructor(@Inject(DB) private readonly db: AppDb) {}
 
-  createWorkspace(input: { name: string; ownerId: string }): Workspace {
-    const id = randomUUID();
-    const workspace: Workspace = {
-      id,
-      name: input.name,
-      slug: this.slugify(input.name),
-      createdAt: isoNow()
-    };
-    this.workspaces.set(id, workspace);
-    this.memberships.set(id, [
-      {
-        id: randomUUID(),
-        workspaceId: id,
-        userId: input.ownerId,
-        role: "owner"
-      }
-    ]);
-    return workspace;
-  }
-
-  listForUser(userId: string): Workspace[] {
-    const workspaceIds = [...this.memberships.entries()]
-      .filter(([, rows]) => rows.some((row) => row.userId === userId))
-      .map(([workspaceId]) => workspaceId);
-    return workspaceIds.flatMap((workspaceId) => {
-      const workspace = this.workspaces.get(workspaceId);
-      return workspace ? [workspace] : [];
+  async createWorkspace(input: { name: string; ownerId: string }): Promise<Workspace> {
+    await this.ensureUser(input.ownerId);
+    const slug = `${this.slugify(input.name)}-${input.ownerId.slice(-6)}`;
+    const [workspace] = await this.db
+      .insert(workspaces)
+      .values({ name: input.name, slug })
+      .returning();
+    if (!workspace) {
+      throw new Error("Workspace creation failed");
+    }
+    await this.db.insert(workspaceMemberships).values({
+      workspaceId: workspace.id,
+      userId: input.ownerId,
+      role: "owner"
     });
+    return this.toWorkspace(workspace);
   }
 
-  listMemberships(workspaceId: string): WorkspaceMembership[] {
-    return this.memberships.get(workspaceId) ?? [];
+  async listForUser(userId: string): Promise<Workspace[]> {
+    const rows = await this.db
+      .select({ workspace: workspaces })
+      .from(workspaceMemberships)
+      .innerJoin(workspaces, eq(workspaces.id, workspaceMemberships.workspaceId))
+      .where(eq(workspaceMemberships.userId, userId));
+    return rows.map((row) => this.toWorkspace(row.workspace));
   }
 
-  isMember(workspaceId: string, userId: string): boolean {
-    return this.listMemberships(workspaceId).some((membership) => membership.userId === userId);
+  async listMemberships(workspaceId: string): Promise<WorkspaceMembership[]> {
+    const rows = await this.db
+      .select()
+      .from(workspaceMemberships)
+      .where(eq(workspaceMemberships.workspaceId, workspaceId));
+    return rows.map((row) => ({
+      id: row.id,
+      workspaceId: row.workspaceId,
+      userId: row.userId,
+      role: row.role
+    }));
   }
 
-  assertMember(workspaceId: string, userId: string): void {
-    if (!this.isMember(workspaceId, userId)) {
+  async isMember(workspaceId: string, userId: string): Promise<boolean> {
+    const rows = await this.db
+      .select({ id: workspaceMemberships.id })
+      .from(workspaceMemberships)
+      .where(and(eq(workspaceMemberships.workspaceId, workspaceId), eq(workspaceMemberships.userId, userId)))
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  async assertMember(workspaceId: string, userId: string): Promise<void> {
+    if (!(await this.isMember(workspaceId, userId))) {
       throw new ForbiddenException("User is not a member of this workspace");
     }
   }
 
-  ensureWorkspaceForUser(userId: string): Workspace {
-    const existing = this.listForUser(userId)[0];
+  async ensureWorkspaceForUser(userId: string): Promise<Workspace> {
+    await this.ensureUser(userId);
+    const existing = (await this.listForUser(userId))[0];
     if (existing) {
       return existing;
     }
     return this.createWorkspace({ name: "Personal Workspace", ownerId: userId });
+  }
+
+  private async ensureUser(userId: string): Promise<void> {
+    await this.db
+      .insert(users)
+      .values({ id: userId, displayName: "Workspace Member" })
+      .onConflictDoNothing();
+  }
+
+  private toWorkspace(row: typeof workspaces.$inferSelect): Workspace {
+    return {
+      id: row.id,
+      name: row.name,
+      slug: row.slug,
+      createdAt: row.createdAt.toISOString()
+    };
   }
 
   private slugify(value: string): string {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,13 @@ services:
       POSTGRES_PASSWORD: postgres
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d gen_image_studio"]
+      interval: 2s
+      timeout: 5s
+      retries: 20
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
 volumes:
   postgres_data:
-

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,22 +28,23 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: "docker compose down -v && docker compose up -d --wait postgres && pnpm --filter @gen-image-studio/api db:migrate && pnpm --filter @gen-image-studio/api build && pnpm --filter @gen-image-studio/api start",
+      command: "sh -c 'pids=$(lsof -ti:4000 || true); if [ -n \"$pids\" ]; then kill $pids; fi; docker compose down -v && docker compose up -d --wait postgres && pnpm --filter @gen-image-studio/api db:migrate && pnpm --filter @gen-image-studio/api build && pnpm --filter @gen-image-studio/api start'",
       url: "http://127.0.0.1:4000/graphql",
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
       env: {
         API_PORT: "4000",
         WEB_ORIGIN: "http://127.0.0.1:5173",
         PASSKEY_RP_ID: "localhost",
         PASSKEY_ORIGIN: "http://127.0.0.1:5173",
+        PROVIDER_SECRET_KEY: process.env.PROVIDER_SECRET_KEY ?? "playwright-provider-secret",
         ENABLE_E2E_PASSWORD_LOGIN: "true",
         E2E_TEST_ACCOUNTS_JSON: process.env.E2E_TEST_ACCOUNTS_JSON ?? JSON.stringify(testAccounts)
       }
     },
     {
-      command: "pnpm --filter @gen-image-studio/web dev",
+      command: "sh -c 'pids=$(lsof -ti:5173 || true); if [ -n \"$pids\" ]; then kill $pids; fi; pnpm --filter @gen-image-studio/web dev'",
       url: "http://127.0.0.1:5173",
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
       env: {
         VITE_GRAPHQL_URL: "http://127.0.0.1:4000/graphql"
       }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: "pnpm --filter @gen-image-studio/api build && pnpm --filter @gen-image-studio/api start",
+      command: "docker compose down -v && docker compose up -d --wait postgres && pnpm --filter @gen-image-studio/api db:migrate && pnpm --filter @gen-image-studio/api build && pnpm --filter @gen-image-studio/api start",
       url: "http://127.0.0.1:4000/graphql",
       reuseExistingServer: !process.env.CI,
       env: {


### PR DESCRIPTION
## Summary
- Closes #3 by replacing in-memory workspace, membership, provider profile, skill, and skill version storage with Drizzle/PostgreSQL-backed services.
- Keeps provider API keys server-only and redacted while persisting encrypted values in `model_provider_profiles`.
- Persists Agent Skill uploads through `assets`, `skills`, and `skill_versions` rows.
- Updates Playwright e2e to reset/start Docker Postgres, wait for health, run migrations, and then start fresh API/web servers.

## Notes
- CI is intentionally skipped for now.
- Full passkey verification/session work remains a follow-up; this PR preserves the existing gated e2e password-login path.
- The e2e database is reset with `docker compose down -v` before each Playwright run so tests are deterministic against persisted state.
- `PROVIDER_SECRET_KEY` is required outside the explicit e2e login path for persisted provider key encryption.

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm test:e2e`