### PR TITLE
Implement session-backed passkey authentication

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -17,7 +17,7 @@ import { WorkspacesModule } from "./workspaces/workspaces.module";
       autoSchemaFile: true,
       sortSchema: true,
       playground: true,
-      context: ({ req }: { req: unknown }) => ({ req })
+      context: ({ req, res }: { req: unknown; res: unknown }) => ({ req, res })
     }),
     DbModule,
     WorkspacesModule,

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
+import { DbModule } from "../db/db.module";
 import { AuthResolver } from "./auth.resolver";
 import { AuthService } from "./auth.service";
 
 @Module({
+  imports: [DbModule],
   providers: [AuthService, AuthResolver],
   exports: [AuthService]
 })
 export class AuthModule {}
-

--- a/apps/api/src/auth/auth.resolver.ts
+++ b/apps/api/src/auth/auth.resolver.ts
@@ -1,38 +1,72 @@
 import { Args, Context, Mutation, Query, Resolver } from "@nestjs/graphql";
-import { currentUserId } from "../workspaces/workspaces.resolver";
 import { AuthService } from "./auth.service";
-import { CurrentUser, LoginResult, PasskeyChallenge } from "./auth.types";
+import { CurrentUser, LoginResult, PasskeyOptions } from "./auth.types";
+import {
+  clearSessionCookie,
+  getSessionUser,
+  RequestWithHeaders,
+  requireSessionUser,
+  ResponseWithHeaders,
+  setSessionCookie
+} from "./session";
 
 @Resolver()
 export class AuthResolver {
   constructor(private readonly auth: AuthService) {}
 
-  @Query(() => CurrentUser)
-  currentUser(@Context("req") req: { headers: Record<string, string | undefined> }): CurrentUser {
-    const headerUserId = req.headers["x-user-id"];
-    return this.auth.currentUser(headerUserId);
+  @Query(() => CurrentUser, { nullable: true })
+  currentUser(@Context("req") req: RequestWithHeaders): Promise<CurrentUser | null> {
+    return this.auth.currentUser(getSessionUser(req)?.userId);
   }
 
-  @Mutation(() => PasskeyChallenge)
-  startPasskeyRegistration(): PasskeyChallenge {
-    return this.auth.startPasskeyRegistration();
+  @Mutation(() => PasskeyOptions)
+  startPasskeyRegistration(@Context("req") req: RequestWithHeaders): Promise<PasskeyOptions> {
+    return this.auth.startPasskeyRegistration(requireSessionUser(req).userId);
   }
 
-  @Mutation(() => PasskeyChallenge)
-  startPasskeyAuthentication(): PasskeyChallenge {
+  @Mutation(() => PasskeyOptions)
+  startPasskeyAuthentication(): Promise<PasskeyOptions> {
     return this.auth.startPasskeyAuthentication();
   }
 
-  @Mutation(() => Boolean)
-  finishPasskeyCeremony(@Args("challengeId", { type: () => String }) challengeId: string): boolean {
-    return this.auth.finishPasskeyCeremony(challengeId);
+  @Mutation(() => LoginResult)
+  async finishPasskeyRegistration(
+    @Args("challengeId", { type: () => String }) challengeId: string,
+    @Args("responseJson", { type: () => String }) responseJson: string,
+    @Context("res") res: ResponseWithHeaders
+  ): Promise<LoginResult> {
+    const result = await this.auth.finishPasskeyRegistration(challengeId, responseJson);
+    setSessionCookie(res, result.userId);
+    return result;
+  }
+
+  @Mutation(() => LoginResult)
+  async finishPasskeyAuthentication(
+    @Args("challengeId", { type: () => String }) challengeId: string,
+    @Args("responseJson", { type: () => String }) responseJson: string,
+    @Context("res") res: ResponseWithHeaders
+  ): Promise<LoginResult> {
+    const result = await this.auth.finishPasskeyAuthentication(challengeId, responseJson);
+    setSessionCookie(res, result.userId);
+    return result;
   }
 
   @Mutation(() => LoginResult, { nullable: true })
-  loginWithPassword(
+  async loginWithPassword(
     @Args("email", { type: () => String }) email: string,
-    @Args("password", { type: () => String }) password: string
-  ): LoginResult | null {
-    return this.auth.loginWithPassword(email, password);
+    @Args("password", { type: () => String }) password: string,
+    @Context("res") res: ResponseWithHeaders
+  ): Promise<LoginResult | null> {
+    const result = await this.auth.loginWithPassword(email, password);
+    if (result) {
+      setSessionCookie(res, result.userId);
+    }
+    return result;
+  }
+
+  @Mutation(() => Boolean)
+  logout(@Context("res") res: ResponseWithHeaders): boolean {
+    clearSessionCookie(res);
+    return true;
   }
 }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,7 +1,22 @@
-import { Injectable } from "@nestjs/common";
-import { randomBytes, randomUUID } from "node:crypto";
-import { isoNow } from "../common/date";
-import { CurrentUser, LoginResult, PasskeyChallenge } from "./auth.types";
+import { BadRequestException, Injectable } from "@nestjs/common";
+import { Inject } from "@nestjs/common";
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse
+} from "@simplewebauthn/server";
+import type {
+  AuthenticationResponseJSON,
+  AuthenticatorTransportFuture,
+  RegistrationResponseJSON,
+  WebAuthnCredential
+} from "@simplewebauthn/server";
+import { and, eq, isNull } from "drizzle-orm";
+import { DB } from "../db/db.module";
+import { passkeyCredentials, users, webauthnChallenges } from "../db/schema";
+import { AppDb } from "../db/types";
+import { CurrentUser, LoginResult, PasskeyOptions } from "./auth.types";
 
 interface TestAccount {
   id: string;
@@ -12,39 +27,152 @@ interface TestAccount {
 
 @Injectable()
 export class AuthService {
-  private readonly challenges = new Map<string, PasskeyChallenge>();
   private readonly testAccounts: TestAccount[];
 
-  constructor() {
+  constructor(@Inject(DB) private readonly db: AppDb) {
     this.testAccounts = this.loadTestAccounts();
   }
 
-  currentUser(userId?: string): CurrentUser {
-    const account = this.testAccounts.find((candidate) => candidate.id === userId) ?? this.testAccounts[0];
+  async currentUser(userId?: string): Promise<CurrentUser | null> {
+    if (!userId) {
+      return null;
+    }
+    const [user] = await this.db.select().from(users).where(eq(users.id, userId)).limit(1);
+    if (!user) {
+      return null;
+    }
     return {
-      id: account?.id ?? "00000000-0000-4000-8000-000000000001",
-      displayName: account?.displayName ?? "Local Developer"
+      id: user.id,
+      displayName: user.displayName
     };
   }
 
-  startPasskeyRegistration(): PasskeyChallenge {
-    return this.createChallenge();
-  }
-
-  startPasskeyAuthentication(): PasskeyChallenge {
-    return this.createChallenge();
-  }
-
-  finishPasskeyCeremony(challengeId: string): boolean {
-    const challenge = this.challenges.get(challengeId);
-    if (!challenge) {
-      return false;
+  async startPasskeyRegistration(userId: string): Promise<PasskeyOptions> {
+    const [user] = await this.db.select().from(users).where(eq(users.id, userId)).limit(1);
+    if (!user) {
+      throw new BadRequestException("Authenticated user not found");
     }
-    this.challenges.delete(challengeId);
-    return true;
+    const credentials = await this.db
+      .select()
+      .from(passkeyCredentials)
+      .where(eq(passkeyCredentials.userId, userId));
+    const options = await generateRegistrationOptions({
+      rpName: process.env.PASSKEY_RP_NAME ?? "Gen Image Studio",
+      rpID: this.rpId(),
+      userName: user.email ?? user.id,
+      userID: Buffer.from(user.id),
+      userDisplayName: user.displayName,
+      attestationType: "none",
+      excludeCredentials: credentials.map((credential) => ({
+        id: credential.credentialId,
+        transports: credential.transports as AuthenticatorTransportFuture[]
+      })),
+      authenticatorSelection: {
+        residentKey: "preferred",
+        userVerification: "preferred"
+      }
+    });
+    const [challenge] = await this.db
+      .insert(webauthnChallenges)
+      .values({
+        userId,
+        challenge: options.challenge,
+        purpose: "registration",
+        expiresAt: this.challengeExpiry()
+      })
+      .returning();
+    if (!challenge) {
+      throw new Error("Passkey registration challenge creation failed");
+    }
+    return { challengeId: challenge.id, optionsJson: JSON.stringify(options) };
   }
 
-  loginWithPassword(email: string, password: string): LoginResult | null {
+  async finishPasskeyRegistration(challengeId: string, responseJson: string): Promise<LoginResult> {
+    const challenge = await this.consumeChallenge(challengeId, "registration");
+    if (!challenge.userId) {
+      throw new BadRequestException("Registration challenge is not bound to a user");
+    }
+    const response = JSON.parse(responseJson) as RegistrationResponseJSON;
+    const verification = await verifyRegistrationResponse({
+      response,
+      expectedChallenge: challenge.challenge,
+      expectedOrigin: this.origin(),
+      expectedRPID: this.rpId(),
+      requireUserVerification: false
+    });
+    if (!verification.verified) {
+      throw new BadRequestException("Passkey registration verification failed");
+    }
+    const { credential, credentialBackedUp } = verification.registrationInfo;
+    await this.db
+      .insert(passkeyCredentials)
+      .values({
+        userId: challenge.userId,
+        credentialId: credential.id,
+        publicKey: Buffer.from(credential.publicKey).toString("base64url"),
+        counter: credential.counter,
+        transports: response.response.transports ?? [],
+        backedUp: credentialBackedUp
+      })
+      .onConflictDoNothing();
+    return this.loginResultForUser(challenge.userId);
+  }
+
+  async startPasskeyAuthentication(): Promise<PasskeyOptions> {
+    const options = await generateAuthenticationOptions({
+      rpID: this.rpId(),
+      userVerification: "preferred"
+    });
+    const [challenge] = await this.db
+      .insert(webauthnChallenges)
+      .values({
+        challenge: options.challenge,
+        purpose: "authentication",
+        expiresAt: this.challengeExpiry()
+      })
+      .returning();
+    if (!challenge) {
+      throw new Error("Passkey authentication challenge creation failed");
+    }
+    return { challengeId: challenge.id, optionsJson: JSON.stringify(options) };
+  }
+
+  async finishPasskeyAuthentication(challengeId: string, responseJson: string): Promise<LoginResult> {
+    const challenge = await this.consumeChallenge(challengeId, "authentication");
+    const response = JSON.parse(responseJson) as AuthenticationResponseJSON;
+    const [storedCredential] = await this.db
+      .select()
+      .from(passkeyCredentials)
+      .where(eq(passkeyCredentials.credentialId, response.id))
+      .limit(1);
+    if (!storedCredential) {
+      throw new BadRequestException("Passkey credential not found");
+    }
+    const credential: WebAuthnCredential = {
+      id: storedCredential.credentialId,
+      publicKey: Buffer.from(storedCredential.publicKey, "base64url"),
+      counter: storedCredential.counter,
+      transports: storedCredential.transports as AuthenticatorTransportFuture[]
+    };
+    const verification = await verifyAuthenticationResponse({
+      response,
+      expectedChallenge: challenge.challenge,
+      expectedOrigin: this.origin(),
+      expectedRPID: this.rpId(),
+      credential,
+      requireUserVerification: false
+    });
+    if (!verification.verified) {
+      throw new BadRequestException("Passkey authentication verification failed");
+    }
+    await this.db
+      .update(passkeyCredentials)
+      .set({ counter: verification.authenticationInfo.newCounter, updatedAt: new Date() })
+      .where(eq(passkeyCredentials.id, storedCredential.id));
+    return this.loginResultForUser(storedCredential.userId);
+  }
+
+  async loginWithPassword(email: string, password: string): Promise<LoginResult | null> {
     if (process.env.ENABLE_E2E_PASSWORD_LOGIN !== "true") {
       return null;
     }
@@ -52,6 +180,7 @@ export class AuthService {
     if (!account) {
       return null;
     }
+    await this.ensureUser(account);
     return {
       userId: account.id,
       displayName: account.displayName,
@@ -59,16 +188,60 @@ export class AuthService {
     };
   }
 
-  private createChallenge(): PasskeyChallenge {
-    const challenge: PasskeyChallenge = {
-      challengeId: randomUUID(),
-      challenge: randomBytes(32).toString("base64url"),
-      rpId: process.env.PASSKEY_RP_ID ?? "localhost",
-      origin: process.env.PASSKEY_ORIGIN ?? "http://localhost:5173",
-      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString()
+  private async consumeChallenge(challengeId: string, purpose: "authentication" | "registration") {
+    const [challenge] = await this.db
+      .select()
+      .from(webauthnChallenges)
+      .where(
+        and(
+          eq(webauthnChallenges.id, challengeId),
+          eq(webauthnChallenges.purpose, purpose),
+          isNull(webauthnChallenges.consumedAt)
+        )
+      )
+      .limit(1);
+    if (!challenge || challenge.expiresAt.getTime() <= Date.now()) {
+      throw new BadRequestException("Passkey challenge is missing or expired");
+    }
+    await this.db
+      .update(webauthnChallenges)
+      .set({ consumedAt: new Date() })
+      .where(eq(webauthnChallenges.id, challenge.id));
+    return challenge;
+  }
+
+  private async loginResultForUser(userId: string): Promise<LoginResult> {
+    const [user] = await this.db.select().from(users).where(eq(users.id, userId)).limit(1);
+    if (!user) {
+      throw new BadRequestException("User not found");
+    }
+    return {
+      userId: user.id,
+      displayName: user.displayName,
+      email: user.email ?? ""
     };
-    this.challenges.set(challenge.challengeId, challenge);
-    return { ...challenge, expiresAt: challenge.expiresAt || isoNow() };
+  }
+
+  private async ensureUser(account: TestAccount): Promise<void> {
+    await this.db
+      .insert(users)
+      .values({ id: account.id, displayName: account.displayName, email: account.email })
+      .onConflictDoUpdate({
+        target: users.id,
+        set: { displayName: account.displayName, email: account.email, updatedAt: new Date() }
+      });
+  }
+
+  private challengeExpiry(): Date {
+    return new Date(Date.now() + 5 * 60 * 1000);
+  }
+
+  private rpId(): string {
+    return process.env.PASSKEY_RP_ID ?? "localhost";
+  }
+
+  private origin(): string {
+    return process.env.PASSKEY_ORIGIN ?? "http://localhost:5173";
   }
 
   private loadTestAccounts(): TestAccount[] {

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -12,7 +12,7 @@ import type {
   RegistrationResponseJSON,
   WebAuthnCredential
 } from "@simplewebauthn/server";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, gt, isNull } from "drizzle-orm";
 import { DB } from "../db/db.module";
 import { passkeyCredentials, users, webauthnChallenges } from "../db/schema";
 import { AppDb } from "../db/types";
@@ -68,7 +68,8 @@ export class AuthService {
         transports: credential.transports as AuthenticatorTransportFuture[]
       })),
       authenticatorSelection: {
-        residentKey: "preferred",
+        residentKey: "required",
+        requireResidentKey: true,
         userVerification: "preferred"
       }
     });
@@ -190,23 +191,20 @@ export class AuthService {
 
   private async consumeChallenge(challengeId: string, purpose: "authentication" | "registration") {
     const [challenge] = await this.db
-      .select()
-      .from(webauthnChallenges)
+      .update(webauthnChallenges)
+      .set({ consumedAt: new Date() })
       .where(
         and(
           eq(webauthnChallenges.id, challengeId),
           eq(webauthnChallenges.purpose, purpose),
-          isNull(webauthnChallenges.consumedAt)
+          isNull(webauthnChallenges.consumedAt),
+          gt(webauthnChallenges.expiresAt, new Date())
         )
       )
-      .limit(1);
-    if (!challenge || challenge.expiresAt.getTime() <= Date.now()) {
+      .returning();
+    if (!challenge) {
       throw new BadRequestException("Passkey challenge is missing or expired");
     }
-    await this.db
-      .update(webauthnChallenges)
-      .set({ consumedAt: new Date() })
-      .where(eq(webauthnChallenges.id, challenge.id));
     return challenge;
   }
 

--- a/apps/api/src/auth/auth.types.ts
+++ b/apps/api/src/auth/auth.types.ts
@@ -22,19 +22,10 @@ export class LoginResult {
 }
 
 @ObjectType()
-export class PasskeyChallenge {
+export class PasskeyOptions {
   @Field()
   challengeId: string;
 
   @Field()
-  challenge: string;
-
-  @Field()
-  rpId: string;
-
-  @Field()
-  origin: string;
-
-  @Field()
-  expiresAt: string;
+  optionsJson: string;
 }

--- a/apps/api/src/auth/session.ts
+++ b/apps/api/src/auth/session.ts
@@ -1,0 +1,110 @@
+import { UnauthorizedException } from "@nestjs/common";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const COOKIE_NAME = "gis_session";
+const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+export interface SessionUser {
+  userId: string;
+}
+
+export interface RequestWithHeaders {
+  headers: Record<string, string | string[] | undefined>;
+}
+
+export interface ResponseWithHeaders {
+  setHeader(name: string, value: string | string[]): void;
+  getHeader(name: string): number | string | string[] | undefined;
+}
+
+interface SessionPayload {
+  userId: string;
+  exp: number;
+}
+
+export function getSessionUser(req: RequestWithHeaders): SessionUser | undefined {
+  const rawCookie = headerValue(req.headers.cookie);
+  const token = parseCookies(rawCookie)[COOKIE_NAME];
+  if (!token) {
+    return undefined;
+  }
+  const [payloadRaw, signature] = token.split(".");
+  if (!payloadRaw || !signature) {
+    return undefined;
+  }
+  const expected = sign(payloadRaw);
+  if (!safeEqual(signature, expected)) {
+    return undefined;
+  }
+  const payload = JSON.parse(Buffer.from(payloadRaw, "base64url").toString("utf8")) as SessionPayload;
+  if (!payload.userId || payload.exp <= Math.floor(Date.now() / 1000)) {
+    return undefined;
+  }
+  return { userId: payload.userId };
+}
+
+export function requireSessionUser(req: RequestWithHeaders): SessionUser {
+  const user = getSessionUser(req);
+  if (!user) {
+    throw new UnauthorizedException("Missing authenticated user");
+  }
+  return user;
+}
+
+export function setSessionCookie(res: ResponseWithHeaders, userId: string): void {
+  const exp = Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS;
+  const payload = Buffer.from(JSON.stringify({ userId, exp } satisfies SessionPayload)).toString("base64url");
+  appendSetCookie(res, `${COOKIE_NAME}=${payload}.${sign(payload)}; ${cookieAttributes(SESSION_TTL_SECONDS)}`);
+}
+
+export function clearSessionCookie(res: ResponseWithHeaders): void {
+  appendSetCookie(res, `${COOKIE_NAME}=; ${cookieAttributes(0)}`);
+}
+
+function sessionSecret(): string {
+  const secret = process.env.SESSION_SECRET?.trim();
+  if (!secret) {
+    throw new Error("SESSION_SECRET is required for authenticated sessions");
+  }
+  return secret;
+}
+
+function sign(value: string): string {
+  return createHmac("sha256", sessionSecret()).update(value).digest("base64url");
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function parseCookies(rawCookie: string | undefined): Record<string, string> {
+  if (!rawCookie) {
+    return {};
+  }
+  return Object.fromEntries(
+    rawCookie
+      .split(";")
+      .map((part) => part.trim().split("="))
+      .filter((parts): parts is [string, string] => Boolean(parts[0] && parts[1]))
+  );
+}
+
+function appendSetCookie(res: ResponseWithHeaders, cookie: string): void {
+  const existing = res.getHeader("Set-Cookie");
+  if (!existing) {
+    res.setHeader("Set-Cookie", cookie);
+    return;
+  }
+  res.setHeader("Set-Cookie", Array.isArray(existing) ? [...existing, cookie] : [String(existing), cookie]);
+}
+
+function cookieAttributes(maxAge: number): string {
+  const secure = process.env.NODE_ENV === "production" || process.env.SESSION_COOKIE_SECURE === "true";
+  return `HttpOnly; Path=/; SameSite=Lax; Max-Age=${maxAge}${secure ? "; Secure" : ""}`;
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value.join("; ") : value;
+}

--- a/apps/api/src/provider-profiles/provider-profiles.resolver.ts
+++ b/apps/api/src/provider-profiles/provider-profiles.resolver.ts
@@ -1,4 +1,5 @@
 import { Args, Context, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { RequestWithHeaders } from "../auth/session";
 import { currentUserId } from "../workspaces/workspaces.resolver";
 import { ProviderProfile, ProviderProfileInput } from "./provider-profile.types";
 import { ProviderProfilesService } from "./provider-profiles.service";
@@ -10,7 +11,7 @@ export class ProviderProfilesResolver {
   @Query(() => [ProviderProfile])
   providerProfiles(
     @Args("workspaceId", { type: () => String }) workspaceId: string,
-    @Context("req") req: { headers: Record<string, string | undefined> }
+    @Context("req") req: RequestWithHeaders
   ): Promise<ProviderProfile[]> {
     return this.providerProfileService.list(workspaceId, currentUserId(req));
   }
@@ -18,7 +19,7 @@ export class ProviderProfilesResolver {
   @Mutation(() => ProviderProfile)
   createProviderProfile(
     @Args("input", { type: () => ProviderProfileInput }) input: ProviderProfileInput,
-    @Context("req") req: { headers: Record<string, string | undefined> }
+    @Context("req") req: RequestWithHeaders
   ): Promise<ProviderProfile> {
     return this.providerProfileService.create(input, currentUserId(req));
   }

--- a/apps/api/src/skills/skills.resolver.ts
+++ b/apps/api/src/skills/skills.resolver.ts
@@ -1,4 +1,5 @@
 import { Args, Context, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { RequestWithHeaders } from "../auth/session";
 import { currentUserId } from "../workspaces/workspaces.resolver";
 import { Skill, SkillUploadInput, SkillUploadResult } from "./skill.types";
 import { SkillsService } from "./skills.service";
@@ -10,7 +11,7 @@ export class SkillsResolver {
   @Query(() => [Skill])
   skills(
     @Args("workspaceId", { type: () => String }) workspaceId: string,
-    @Context("req") req: { headers: Record<string, string | undefined> }
+    @Context("req") req: RequestWithHeaders
   ): Promise<Skill[]> {
     return this.skillService.list(workspaceId, currentUserId(req));
   }
@@ -18,7 +19,7 @@ export class SkillsResolver {
   @Mutation(() => SkillUploadResult)
   uploadSkill(
     @Args("input", { type: () => SkillUploadInput }) input: SkillUploadInput,
-    @Context("req") req: { headers: Record<string, string | undefined> }
+    @Context("req") req: RequestWithHeaders
   ): Promise<SkillUploadResult> {
     return this.skillService.upload(input, currentUserId(req));
   }

--- a/apps/api/src/workspaces/workspaces.resolver.ts
+++ b/apps/api/src/workspaces/workspaces.resolver.ts
@@ -1,5 +1,6 @@
 import { Args, Context, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { UnauthorizedException } from "@nestjs/common";
+import { RequestWithHeaders, requireSessionUser } from "../auth/session";
 import { WorkspacesService } from "./workspaces.service";
 import { Workspace, WorkspaceMembership } from "./workspace.types";
 
@@ -8,7 +9,7 @@ export class WorkspacesResolver {
   constructor(private readonly workspaces: WorkspacesService) {}
 
   @Query(() => [Workspace])
-  async workspacesForCurrentUser(@Context("req") req: { headers: Record<string, string | undefined> }): Promise<Workspace[]> {
+  async workspacesForCurrentUser(@Context("req") req: RequestWithHeaders): Promise<Workspace[]> {
     const userId = currentUserId(req);
     await this.workspaces.ensureWorkspaceForUser(userId);
     return this.workspaces.listForUser(userId);
@@ -17,7 +18,7 @@ export class WorkspacesResolver {
   @Query(() => [WorkspaceMembership])
   async workspaceMembers(
     @Args("workspaceId", { type: () => String }) workspaceId: string,
-    @Context("req") req: { headers: Record<string, string | undefined> }
+    @Context("req") req: RequestWithHeaders
   ): Promise<WorkspaceMembership[]> {
     await this.workspaces.assertMember(workspaceId, currentUserId(req));
     return this.workspaces.listMemberships(workspaceId);
@@ -26,16 +27,16 @@ export class WorkspacesResolver {
   @Mutation(() => Workspace)
   createWorkspace(
     @Args("name", { type: () => String }) name: string,
-    @Context("req") req: { headers: Record<string, string | undefined> }
+    @Context("req") req: RequestWithHeaders
   ): Promise<Workspace> {
     return this.workspaces.createWorkspace({ name, ownerId: currentUserId(req) });
   }
 }
 
-export function currentUserId(req: { headers: Record<string, string | undefined> }): string {
-  const userId = req.headers["x-user-id"];
-  if (!userId) {
+export function currentUserId(req: RequestWithHeaders): string {
+  try {
+    return requireSessionUser(req).userId;
+  } catch {
     throw new UnauthorizedException("Missing authenticated user");
   }
-  return userId;
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,14 +1,21 @@
 import { useMutation, useQuery } from "@apollo/client";
 import { Button } from "@base-ui/react/button";
+import { startAuthentication, startRegistration } from "@simplewebauthn/browser";
 import { Boxes, KeyRound, Settings, Upload, UsersRound } from "lucide-react";
 import { FormEvent, useMemo, useState } from "react";
 import {
+  CURRENT_USER_QUERY,
   CREATE_PROVIDER_PROFILE,
-  DASHBOARD_QUERY,
+  FINISH_PASSKEY_AUTHENTICATION,
+  FINISH_PASSKEY_REGISTRATION,
   LOGIN_WITH_PASSWORD,
+  LOGOUT,
   PROVIDER_PROFILES_QUERY,
   SKILLS_QUERY,
-  UPLOAD_SKILL
+  START_PASSKEY_AUTHENTICATION,
+  START_PASSKEY_REGISTRATION,
+  UPLOAD_SKILL,
+  WORKSPACES_QUERY
 } from "./graphql";
 
 interface Workspace {
@@ -38,7 +45,10 @@ interface DashboardData {
   currentUser: {
     id: string;
     displayName: string;
-  };
+  } | null;
+}
+
+interface WorkspacesData {
   workspacesForCurrentUser: Workspace[];
 }
 
@@ -57,10 +67,6 @@ interface LoggedInUser {
 }
 
 export function App() {
-  const [loggedInUser, setLoggedInUser] = useState<LoggedInUser | null>(() => {
-    const raw = localStorage.getItem("gen-image-studio:user");
-    return raw ? (JSON.parse(raw) as LoggedInUser) : null;
-  });
   const [email, setEmail] = useState("tester1@example.test");
   const [password, setPassword] = useState("test-password-1");
   const [providerName, setProviderName] = useState("Local OpenAI Compatible");
@@ -76,13 +82,23 @@ version: 0.1.0
 # Studio Image Style
 `);
   const [loginMessage, setLoginMessage] = useState<string | null>(null);
+  const [passkeyMessage, setPasskeyMessage] = useState<string | null>(null);
+  const currentUserQuery = useQuery<DashboardData>(CURRENT_USER_QUERY, {
+    fetchPolicy: "cache-and-network"
+  });
   const [loginWithPassword, loginState] = useMutation(LOGIN_WITH_PASSWORD);
+  const [logoutMutation] = useMutation(LOGOUT);
+  const [startPasskeyRegistrationMutation] = useMutation(START_PASSKEY_REGISTRATION);
+  const [finishPasskeyRegistrationMutation] = useMutation(FINISH_PASSKEY_REGISTRATION);
+  const [startPasskeyAuthenticationMutation] = useMutation(START_PASSKEY_AUTHENTICATION);
+  const [finishPasskeyAuthenticationMutation] = useMutation(FINISH_PASSKEY_AUTHENTICATION);
   const [createProviderProfile, providerMutation] = useMutation(CREATE_PROVIDER_PROFILE);
   const [uploadSkill, skillMutation] = useMutation(UPLOAD_SKILL);
-  const dashboard = useQuery<DashboardData>(DASHBOARD_QUERY, {
-    skip: !loggedInUser
+  const currentUser = currentUserQuery.data?.currentUser;
+  const workspaces = useQuery<WorkspacesData>(WORKSPACES_QUERY, {
+    skip: !currentUser
   });
-  const activeWorkspace = dashboard.data?.workspacesForCurrentUser[0];
+  const activeWorkspace = workspaces.data?.workspacesForCurrentUser[0];
   const providers = useQuery<ProviderProfilesData>(PROVIDER_PROFILES_QUERY, {
     variables: { workspaceId: activeWorkspace?.id ?? "" },
     skip: !activeWorkspace
@@ -94,7 +110,7 @@ version: 0.1.0
 
   const providerRows = providers.data?.providerProfiles ?? [];
   const skillRows = skills.data?.skills ?? [];
-  const currentUserName = loggedInUser?.displayName ?? dashboard.data?.currentUser.displayName ?? "Loading user";
+  const currentUserName = currentUser?.displayName ?? "Loading user";
   const loginError = loginState.error?.message;
   const providerError = providerMutation.error?.message;
   const skillResult = skillMutation.data?.uploadSkill;
@@ -106,11 +122,48 @@ version: 0.1.0
     const result = await loginWithPassword({ variables: { email, password } });
     const user = result.data?.loginWithPassword as LoggedInUser | undefined;
     if (user) {
-      localStorage.setItem("gen-image-studio:user", JSON.stringify(user));
-      setLoggedInUser(user);
+      await currentUserQuery.refetch();
       return;
     }
     setLoginMessage("Invalid test login credentials");
+  }
+
+  async function handlePasskeySignIn() {
+    setLoginMessage(null);
+    try {
+      const started = await startPasskeyAuthenticationMutation();
+      const payload = started.data?.startPasskeyAuthentication as { challengeId: string; optionsJson: string } | undefined;
+      if (!payload) return;
+      const response = await startAuthentication({ optionsJSON: JSON.parse(payload.optionsJson) });
+      await finishPasskeyAuthenticationMutation({
+        variables: { challengeId: payload.challengeId, responseJson: JSON.stringify(response) }
+      });
+      await currentUserQuery.refetch();
+    } catch (error) {
+      setLoginMessage(error instanceof Error ? error.message : "Passkey sign-in failed");
+    }
+  }
+
+  async function handleRegisterPasskey() {
+    setPasskeyMessage(null);
+    try {
+      const started = await startPasskeyRegistrationMutation();
+      const payload = started.data?.startPasskeyRegistration as { challengeId: string; optionsJson: string } | undefined;
+      if (!payload) return;
+      const response = await startRegistration({ optionsJSON: JSON.parse(payload.optionsJson) });
+      await finishPasskeyRegistrationMutation({
+        variables: { challengeId: payload.challengeId, responseJson: JSON.stringify(response) }
+      });
+      setPasskeyMessage("Passkey registered");
+      await currentUserQuery.refetch();
+    } catch (error) {
+      setPasskeyMessage(error instanceof Error ? error.message : "Passkey registration failed");
+    }
+  }
+
+  async function handleLogout() {
+    await logoutMutation();
+    await currentUserQuery.refetch();
   }
 
   async function handleProviderSubmit(event: FormEvent<HTMLFormElement>) {
@@ -150,7 +203,7 @@ version: 0.1.0
     });
   }
 
-  if (!loggedInUser) {
+  if (!currentUser) {
     return (
       <main className="login-page">
         <form className="login-panel" onSubmit={handleLogin}>
@@ -179,6 +232,10 @@ version: 0.1.0
           <Button className="primary-button" type="submit">
             <KeyRound size={18} />
             Sign in
+          </Button>
+          <Button className="secondary-button" type="button" onClick={handlePasskeySignIn}>
+            <KeyRound size={18} />
+            Sign in with passkey
           </Button>
         </form>
       </main>
@@ -227,15 +284,15 @@ version: 0.1.0
             <h1>{activeWorkspace?.name ?? "Workspace setup"}</h1>
           </div>
           <div className="topbar-actions">
-            <Button className="secondary-button">
-              <UsersRound size={18} />
-              Invite
+            <Button className="secondary-button" onClick={handleRegisterPasskey}>
+              <KeyRound size={18} />
+              Register Passkey
             </Button>
-            <Button className="primary-button">
-              <Upload size={18} />
-              Upload Skill
+            <Button className="secondary-button" onClick={handleLogout}>
+              Sign out
             </Button>
           </div>
+          {passkeyMessage ? <p className="success-text topbar-message">{passkeyMessage}</p> : null}
         </header>
 
         <div className="content-grid">

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@apollo/client";
+import { useApolloClient, useMutation, useQuery } from "@apollo/client";
 import { Button } from "@base-ui/react/button";
 import { startAuthentication, startRegistration } from "@simplewebauthn/browser";
 import { Boxes, KeyRound, Settings, Upload, UsersRound } from "lucide-react";
@@ -67,6 +67,7 @@ interface LoggedInUser {
 }
 
 export function App() {
+  const apollo = useApolloClient();
   const [email, setEmail] = useState("tester1@example.test");
   const [password, setPassword] = useState("test-password-1");
   const [providerName, setProviderName] = useState("Local OpenAI Compatible");
@@ -122,7 +123,7 @@ version: 0.1.0
     const result = await loginWithPassword({ variables: { email, password } });
     const user = result.data?.loginWithPassword as LoggedInUser | undefined;
     if (user) {
-      await currentUserQuery.refetch();
+      await apollo.resetStore();
       return;
     }
     setLoginMessage("Invalid test login credentials");
@@ -138,7 +139,7 @@ version: 0.1.0
       await finishPasskeyAuthenticationMutation({
         variables: { challengeId: payload.challengeId, responseJson: JSON.stringify(response) }
       });
-      await currentUserQuery.refetch();
+      await apollo.resetStore();
     } catch (error) {
       setLoginMessage(error instanceof Error ? error.message : "Passkey sign-in failed");
     }
@@ -155,7 +156,7 @@ version: 0.1.0
         variables: { challengeId: payload.challengeId, responseJson: JSON.stringify(response) }
       });
       setPasskeyMessage("Passkey registered");
-      await currentUserQuery.refetch();
+      await apollo.resetStore();
     } catch (error) {
       setPasskeyMessage(error instanceof Error ? error.message : "Passkey registration failed");
     }
@@ -163,6 +164,7 @@ version: 0.1.0
 
   async function handleLogout() {
     await logoutMutation();
+    await apollo.clearStore();
     await currentUserQuery.refetch();
   }
 

--- a/apps/web/src/graphql.ts
+++ b/apps/web/src/graphql.ts
@@ -1,11 +1,16 @@
 import { gql } from "@apollo/client";
 
-export const DASHBOARD_QUERY = gql`
-  query Dashboard {
+export const CURRENT_USER_QUERY = gql`
+  query CurrentUser {
     currentUser {
       id
       displayName
     }
+  }
+`;
+
+export const WORKSPACES_QUERY = gql`
+  query Workspaces {
     workspacesForCurrentUser {
       id
       name
@@ -15,9 +20,53 @@ export const DASHBOARD_QUERY = gql`
   }
 `;
 
+export const LOGOUT = gql`
+  mutation Logout {
+    logout
+  }
+`;
+
 export const LOGIN_WITH_PASSWORD = gql`
   mutation LoginWithPassword($email: String!, $password: String!) {
     loginWithPassword(email: $email, password: $password) {
+      userId
+      displayName
+      email
+    }
+  }
+`;
+
+export const START_PASSKEY_REGISTRATION = gql`
+  mutation StartPasskeyRegistration {
+    startPasskeyRegistration {
+      challengeId
+      optionsJson
+    }
+  }
+`;
+
+export const FINISH_PASSKEY_REGISTRATION = gql`
+  mutation FinishPasskeyRegistration($challengeId: String!, $responseJson: String!) {
+    finishPasskeyRegistration(challengeId: $challengeId, responseJson: $responseJson) {
+      userId
+      displayName
+      email
+    }
+  }
+`;
+
+export const START_PASSKEY_AUTHENTICATION = gql`
+  mutation StartPasskeyAuthentication {
+    startPasskeyAuthentication {
+      challengeId
+      optionsJson
+    }
+  }
+`;
+
+export const FINISH_PASSKEY_AUTHENTICATION = gql`
+  mutation FinishPasskeyAuthentication($challengeId: String!, $responseJson: String!) {
+    finishPasskeyAuthentication(challengeId: $challengeId, responseJson: $responseJson) {
       userId
       displayName
       email

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,4 +1,4 @@
-import { ApolloClient, ApolloLink, ApolloProvider, HttpLink, InMemoryCache } from "@apollo/client";
+import { ApolloClient, ApolloProvider, HttpLink, InMemoryCache } from "@apollo/client";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
@@ -9,21 +9,8 @@ const httpLink = new HttpLink({
   credentials: "include"
 });
 
-const authLink = new ApolloLink((operation, forward) => {
-  const headers = (() => {
-    const raw = localStorage.getItem("gen-image-studio:user");
-    if (!raw) {
-      return {};
-    }
-    const user = JSON.parse(raw) as { userId?: string };
-    return user.userId ? { "x-user-id": user.userId } : {};
-  })();
-  operation.setContext({ headers });
-  return forward(operation);
-});
-
 const client = new ApolloClient({
-  link: authLink.concat(httpLink),
+  link: httpLink,
   cache: new InMemoryCache()
 });
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -169,6 +169,10 @@ button {
   gap: 10px;
 }
 
+.topbar-message {
+  margin-top: 8px;
+}
+
 .primary-button {
   padding: 0 14px;
   background: #245c4f;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     timeout: 8_000
   },
   use: {
-    baseURL: "http://127.0.0.1:5173",
+    baseURL: "http://localhost:5173",
     trace: "on-first-retry"
   },
   projects: [
@@ -29,13 +29,14 @@ export default defineConfig({
   webServer: [
     {
       command: "sh -c 'pids=$(lsof -ti:4000 || true); if [ -n \"$pids\" ]; then kill $pids; fi; docker compose down -v && docker compose up -d --wait postgres && pnpm --filter @gen-image-studio/api db:migrate && pnpm --filter @gen-image-studio/api build && pnpm --filter @gen-image-studio/api start'",
-      url: "http://127.0.0.1:4000/graphql",
+      url: "http://localhost:4000/graphql",
       reuseExistingServer: false,
       env: {
         API_PORT: "4000",
-        WEB_ORIGIN: "http://127.0.0.1:5173",
+        WEB_ORIGIN: "http://localhost:5173",
+        SESSION_SECRET: "playwright-session-secret",
         PASSKEY_RP_ID: "localhost",
-        PASSKEY_ORIGIN: "http://127.0.0.1:5173",
+        PASSKEY_ORIGIN: "http://localhost:5173",
         PROVIDER_SECRET_KEY: process.env.PROVIDER_SECRET_KEY ?? "playwright-provider-secret",
         ENABLE_E2E_PASSWORD_LOGIN: "true",
         E2E_TEST_ACCOUNTS_JSON: process.env.E2E_TEST_ACCOUNTS_JSON ?? JSON.stringify(testAccounts)
@@ -43,10 +44,10 @@ export default defineConfig({
     },
     {
       command: "sh -c 'pids=$(lsof -ti:5173 || true); if [ -n \"$pids\" ]; then kill $pids; fi; pnpm --filter @gen-image-studio/web dev'",
-      url: "http://127.0.0.1:5173",
+      url: "http://localhost:5173",
       reuseExistingServer: false,
       env: {
-        VITE_GRAPHQL_URL: "http://127.0.0.1:4000/graphql"
+        VITE_GRAPHQL_URL: "http://localhost:4000/graphql"
       }
     }
   ]

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -59,6 +59,33 @@ test.describe("foundation workspace flows", () => {
     await expect(page.getByRole("button", { name: "Sign in", exact: true })).toBeVisible();
   });
 
+  test("does not leak cached workspace data when switching users", async ({ page }) => {
+    await resetBrowserState(page);
+    await login(page, accounts[0]);
+    await expect(page.getByText(accounts[0].displayName)).toBeVisible();
+
+    await page.getByRole("button", { name: "Sign out" }).click();
+    await page.getByLabel("Email").fill(accounts[1].email);
+    await page.getByLabel("Password").fill(accounts[1].password);
+    await page.getByRole("button", { name: "Sign in", exact: true }).click();
+
+    await expect(page.getByText(accounts[1].displayName)).toBeVisible();
+    await expect(page.getByText(accounts[0].displayName)).toHaveCount(0);
+    const workspaceIds = await page.evaluate(async () => {
+      const response = await fetch("http://localhost:4000/graphql", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          query: "{ workspacesForCurrentUser { id } }"
+        })
+      });
+      const json = await response.json();
+      return json.data.workspacesForCurrentUser.map((workspace: { id: string }) => workspace.id);
+    });
+    expect(new Set(workspaceIds).size).toBe(workspaceIds.length);
+  });
+
   test("registers a passkey and signs back in with it", async ({ page }) => {
     await addVirtualAuthenticator(page);
     await resetBrowserState(page);

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -13,25 +13,71 @@ async function login(page: Page, account = accounts[0]) {
   await expect(page.getByRole("heading", { name: "Gen Image Studio" })).toBeVisible();
   await page.getByLabel("Email").fill(account.email);
   await page.getByLabel("Password").fill(account.password);
-  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
   await expect(page.getByText(account.displayName)).toBeVisible();
   await expect(page.getByRole("heading", { name: "Personal Workspace" })).toBeVisible();
+}
+
+async function resetBrowserState(page: Page) {
+  await page.context().clearCookies();
+  await page.goto("/");
+  await page.evaluate(() => localStorage.clear());
+}
+
+async function addVirtualAuthenticator(page: Page) {
+  const client = await page.context().newCDPSession(page);
+  await client.send("WebAuthn.enable");
+  await client.send("WebAuthn.addVirtualAuthenticator", {
+    options: {
+      protocol: "ctap2",
+      transport: "internal",
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true
+    }
+  });
 }
 
 test.describe("foundation workspace flows", () => {
   test("allows all five configured test accounts to log in", async ({ page }) => {
     for (const account of accounts) {
-      await page.goto("/");
-      await page.evaluate(() => localStorage.clear());
+      await resetBrowserState(page);
       await login(page, account);
     }
+  });
+
+  test("persists and clears the server session cookie", async ({ page }) => {
+    await resetBrowserState(page);
+    await login(page);
+
+    await page.reload();
+    await expect(page.getByText(accounts[0].displayName)).toBeVisible();
+    await page.getByRole("button", { name: "Sign out" }).click();
+    await expect(page.getByRole("heading", { name: "Gen Image Studio" })).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Sign in", exact: true })).toBeVisible();
+  });
+
+  test("registers a passkey and signs back in with it", async ({ page }) => {
+    await addVirtualAuthenticator(page);
+    await resetBrowserState(page);
+    await login(page);
+
+    await page.getByRole("button", { name: "Register Passkey" }).click();
+    await expect(page.getByText("Passkey registered")).toBeVisible();
+    await page.getByRole("button", { name: "Sign out" }).click();
+
+    await page.getByRole("button", { name: "Sign in with passkey" }).click();
+    await expect(page.getByText(accounts[0].displayName)).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Personal Workspace" })).toBeVisible();
   });
 
   test("rejects invalid password login", async ({ page }) => {
     await page.goto("/");
     await page.getByLabel("Email").fill(accounts[0].email);
     await page.getByLabel("Password").fill("wrong-password");
-    await page.getByRole("button", { name: "Sign in" }).click();
+    await page.getByRole("button", { name: "Sign in", exact: true }).click();
     await expect(page.getByText("Invalid test login credentials")).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

- Closes #5 by replacing client-controlled user headers with signed HTTP-only session cookies for GraphQL identity.
- Implements SimpleWebAuthn registration and authentication with Drizzle-backed challenge and credential persistence, atomic challenge consumption, and discoverable passkey registration.
- Updates the frontend to use cookie-backed login, logout, cache-safe session switching, passkey registration, and passkey sign-in without localStorage auth headers.
- Expands Playwright e2e to cover five test accounts, session reload/logout, same-browser user switching, and a virtual-authenticator passkey ceremony.

## Linked Issue

Closes #5

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gen-image-studio/issues/5#issuecomment-4349276197

## Validation

- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:e2e

