### PR TITLE
Implement workspace member collaboration controls

### DIFF
--- a/apps/api/src/workspaces/workspace.types.ts
+++ b/apps/api/src/workspaces/workspace.types.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType, registerEnumType } from "@nestjs/graphql";
+import { Field, InputType, ObjectType, registerEnumType } from "@nestjs/graphql";
 
 type WorkspaceRole = "owner" | "admin" | "member" | "viewer";
 
@@ -36,6 +36,48 @@ export class WorkspaceMembership {
 
   @Field()
   userId: string;
+
+  @Field(() => WorkspaceRoleGql)
+  role: WorkspaceRole;
+}
+
+@ObjectType()
+export class WorkspaceMember {
+  @Field()
+  id: string;
+
+  @Field()
+  workspaceId: string;
+
+  @Field()
+  userId: string;
+
+  @Field()
+  displayName: string;
+
+  @Field({ nullable: true })
+  email?: string;
+
+  @Field(() => WorkspaceRoleGql)
+  role: WorkspaceRole;
+}
+
+@InputType()
+export class AddWorkspaceMemberInput {
+  @Field()
+  workspaceId: string;
+
+  @Field()
+  email: string;
+
+  @Field(() => WorkspaceRoleGql)
+  role: WorkspaceRole;
+}
+
+@InputType()
+export class UpdateWorkspaceMemberRoleInput {
+  @Field()
+  membershipId: string;
 
   @Field(() => WorkspaceRoleGql)
   role: WorkspaceRole;

--- a/apps/api/src/workspaces/workspaces.resolver.ts
+++ b/apps/api/src/workspaces/workspaces.resolver.ts
@@ -2,7 +2,12 @@ import { Args, Context, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { UnauthorizedException } from "@nestjs/common";
 import { RequestWithHeaders, requireSessionUser } from "../auth/session";
 import { WorkspacesService } from "./workspaces.service";
-import { Workspace, WorkspaceMembership } from "./workspace.types";
+import {
+  AddWorkspaceMemberInput,
+  UpdateWorkspaceMemberRoleInput,
+  Workspace,
+  WorkspaceMember
+} from "./workspace.types";
 
 @Resolver(() => Workspace)
 export class WorkspacesResolver {
@@ -15,11 +20,11 @@ export class WorkspacesResolver {
     return this.workspaces.listForUser(userId);
   }
 
-  @Query(() => [WorkspaceMembership])
+  @Query(() => [WorkspaceMember])
   async workspaceMembers(
     @Args("workspaceId", { type: () => String }) workspaceId: string,
     @Context("req") req: RequestWithHeaders
-  ): Promise<WorkspaceMembership[]> {
+  ): Promise<WorkspaceMember[]> {
     await this.workspaces.assertMember(workspaceId, currentUserId(req));
     return this.workspaces.listMemberships(workspaceId);
   }
@@ -30,6 +35,30 @@ export class WorkspacesResolver {
     @Context("req") req: RequestWithHeaders
   ): Promise<Workspace> {
     return this.workspaces.createWorkspace({ name, ownerId: currentUserId(req) });
+  }
+
+  @Mutation(() => WorkspaceMember)
+  addWorkspaceMember(
+    @Args("input", { type: () => AddWorkspaceMemberInput }) input: AddWorkspaceMemberInput,
+    @Context("req") req: RequestWithHeaders
+  ): Promise<WorkspaceMember> {
+    return this.workspaces.addMember(input, currentUserId(req));
+  }
+
+  @Mutation(() => WorkspaceMember)
+  updateWorkspaceMemberRole(
+    @Args("input", { type: () => UpdateWorkspaceMemberRoleInput }) input: UpdateWorkspaceMemberRoleInput,
+    @Context("req") req: RequestWithHeaders
+  ): Promise<WorkspaceMember> {
+    return this.workspaces.updateMemberRole(input, currentUserId(req));
+  }
+
+  @Mutation(() => Boolean)
+  removeWorkspaceMember(
+    @Args("membershipId", { type: () => String }) membershipId: string,
+    @Context("req") req: RequestWithHeaders
+  ): Promise<boolean> {
+    return this.workspaces.removeMember(membershipId, currentUserId(req));
   }
 }
 

--- a/apps/api/src/workspaces/workspaces.service.ts
+++ b/apps/api/src/workspaces/workspaces.service.ts
@@ -70,13 +70,13 @@ export class WorkspacesService {
     if (!user) {
       throw new NotFoundException("User with that email does not exist");
     }
+    const existing = await this.findMembership(input.workspaceId, user.id);
+    if (existing) {
+      return this.toWorkspaceMember(existing, user);
+    }
     const [membership] = await this.db
       .insert(workspaceMemberships)
       .values({ workspaceId: input.workspaceId, userId: user.id, role: input.role })
-      .onConflictDoUpdate({
-        target: [workspaceMemberships.userId, workspaceMemberships.workspaceId],
-        set: { role: input.role, updatedAt: new Date() }
-      })
       .returning();
     if (!membership) {
       throw new Error("Workspace member add failed");
@@ -176,6 +176,18 @@ export class WorkspacesService {
     if (!membership) {
       throw new NotFoundException("Workspace membership not found");
     }
+    return membership;
+  }
+
+  private async findMembership(
+    workspaceId: string,
+    userId: string
+  ): Promise<typeof workspaceMemberships.$inferSelect | undefined> {
+    const [membership] = await this.db
+      .select()
+      .from(workspaceMemberships)
+      .where(and(eq(workspaceMemberships.workspaceId, workspaceId), eq(workspaceMemberships.userId, userId)))
+      .limit(1);
     return membership;
   }
 

--- a/apps/api/src/workspaces/workspaces.service.ts
+++ b/apps/api/src/workspaces/workspaces.service.ts
@@ -1,11 +1,13 @@
-import { ForbiddenException, Injectable } from "@nestjs/common";
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from "@nestjs/common";
 import { Inject } from "@nestjs/common";
 import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import { DB } from "../db/db.module";
 import { workspaceMemberships, workspaces, users } from "../db/schema";
 import { AppDb } from "../db/types";
-import { Workspace, WorkspaceMembership } from "./workspace.types";
+import { Workspace, WorkspaceMember, WorkspaceMembership } from "./workspace.types";
+
+const membershipManagerRoles = new Set<WorkspaceMembership["role"]>(["owner", "admin"]);
 
 @Injectable()
 export class WorkspacesService {
@@ -34,17 +36,13 @@ export class WorkspacesService {
     return rows.map((row) => this.toWorkspace(row.workspace));
   }
 
-  async listMemberships(workspaceId: string): Promise<WorkspaceMembership[]> {
+  async listMemberships(workspaceId: string): Promise<WorkspaceMember[]> {
     const rows = await this.db
-      .select()
+      .select({ membership: workspaceMemberships, user: users })
       .from(workspaceMemberships)
+      .innerJoin(users, eq(users.id, workspaceMemberships.userId))
       .where(eq(workspaceMemberships.workspaceId, workspaceId));
-    return rows.map((row) => ({
-      id: row.id,
-      workspaceId: row.workspaceId,
-      userId: row.userId,
-      role: row.role
-    }));
+    return rows.map((row) => this.toWorkspaceMember(row.membership, row.user));
   }
 
   async isMember(workspaceId: string, userId: string): Promise<boolean> {
@@ -60,6 +58,58 @@ export class WorkspacesService {
     if (!(await this.isMember(workspaceId, userId))) {
       throw new ForbiddenException("User is not a member of this workspace");
     }
+  }
+
+  async addMember(input: { workspaceId: string; email: string; role: WorkspaceMembership["role"] }, actorId: string): Promise<WorkspaceMember> {
+    await this.assertCanManageMembers(input.workspaceId, actorId);
+    const [user] = await this.db
+      .select()
+      .from(users)
+      .where(eq(users.email, input.email.trim().toLowerCase()))
+      .limit(1);
+    if (!user) {
+      throw new NotFoundException("User with that email does not exist");
+    }
+    const [membership] = await this.db
+      .insert(workspaceMemberships)
+      .values({ workspaceId: input.workspaceId, userId: user.id, role: input.role })
+      .onConflictDoUpdate({
+        target: [workspaceMemberships.userId, workspaceMemberships.workspaceId],
+        set: { role: input.role, updatedAt: new Date() }
+      })
+      .returning();
+    if (!membership) {
+      throw new Error("Workspace member add failed");
+    }
+    return this.toWorkspaceMember(membership, user);
+  }
+
+  async updateMemberRole(input: { membershipId: string; role: WorkspaceMembership["role"] }, actorId: string): Promise<WorkspaceMember> {
+    const membership = await this.getMembership(input.membershipId);
+    await this.assertCanManageMembers(membership.workspaceId, actorId);
+    if (membership.role === "owner" && input.role !== "owner") {
+      await this.assertNotLastOwner(membership.workspaceId, membership.id);
+    }
+    const [updated] = await this.db
+      .update(workspaceMemberships)
+      .set({ role: input.role, updatedAt: new Date() })
+      .where(eq(workspaceMemberships.id, membership.id))
+      .returning();
+    if (!updated) {
+      throw new Error("Workspace member role update failed");
+    }
+    const user = await this.getUser(updated.userId);
+    return this.toWorkspaceMember(updated, user);
+  }
+
+  async removeMember(membershipId: string, actorId: string): Promise<boolean> {
+    const membership = await this.getMembership(membershipId);
+    await this.assertCanManageMembers(membership.workspaceId, actorId);
+    if (membership.role === "owner") {
+      await this.assertNotLastOwner(membership.workspaceId, membership.id);
+    }
+    await this.db.delete(workspaceMemberships).where(eq(workspaceMemberships.id, membership.id));
+    return true;
   }
 
   async ensureWorkspaceForUser(userId: string): Promise<Workspace> {
@@ -95,6 +145,48 @@ export class WorkspacesService {
       .onConflictDoNothing();
   }
 
+  private async assertCanManageMembers(workspaceId: string, userId: string): Promise<void> {
+    const rows = await this.db
+      .select()
+      .from(workspaceMemberships)
+      .where(and(eq(workspaceMemberships.workspaceId, workspaceId), eq(workspaceMemberships.userId, userId)))
+      .limit(1);
+    const membership = rows[0];
+    if (!membership || !membershipManagerRoles.has(membership.role)) {
+      throw new ForbiddenException("User cannot manage workspace members");
+    }
+  }
+
+  private async assertNotLastOwner(workspaceId: string, membershipId: string): Promise<void> {
+    const owners = await this.db
+      .select({ id: workspaceMemberships.id })
+      .from(workspaceMemberships)
+      .where(and(eq(workspaceMemberships.workspaceId, workspaceId), eq(workspaceMemberships.role, "owner")));
+    if (owners.length === 1 && owners[0]?.id === membershipId) {
+      throw new BadRequestException("Workspace must keep at least one owner");
+    }
+  }
+
+  private async getMembership(membershipId: string): Promise<typeof workspaceMemberships.$inferSelect> {
+    const [membership] = await this.db
+      .select()
+      .from(workspaceMemberships)
+      .where(eq(workspaceMemberships.id, membershipId))
+      .limit(1);
+    if (!membership) {
+      throw new NotFoundException("Workspace membership not found");
+    }
+    return membership;
+  }
+
+  private async getUser(userId: string): Promise<typeof users.$inferSelect> {
+    const [user] = await this.db.select().from(users).where(eq(users.id, userId)).limit(1);
+    if (!user) {
+      throw new NotFoundException("User not found");
+    }
+    return user;
+  }
+
   private async ensureUser(userId: string): Promise<void> {
     await this.db
       .insert(users)
@@ -108,6 +200,20 @@ export class WorkspacesService {
       name: row.name,
       slug: row.slug,
       createdAt: row.createdAt.toISOString()
+    };
+  }
+
+  private toWorkspaceMember(
+    membership: typeof workspaceMemberships.$inferSelect,
+    user: typeof users.$inferSelect
+  ): WorkspaceMember {
+    return {
+      id: membership.id,
+      workspaceId: membership.workspaceId,
+      userId: membership.userId,
+      displayName: user.displayName,
+      ...(user.email ? { email: user.email } : {}),
+      role: membership.role
     };
   }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -95,6 +95,7 @@ export function App() {
   const [providerApiKey, setProviderApiKey] = useState("test-key");
   const [memberEmail, setMemberEmail] = useState("tester2@example.test");
   const [memberRole, setMemberRole] = useState<WorkspaceRole>("member");
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
   const [skillMd, setSkillMd] = useState(`---
 name: studio-image-style
 description: Creates images in the workspace house style.
@@ -123,7 +124,9 @@ version: 0.1.0
   const workspaces = useQuery<WorkspacesData>(WORKSPACES_QUERY, {
     skip: !currentUser
   });
-  const activeWorkspace = workspaces.data?.workspacesForCurrentUser[0];
+  const workspaceRows = workspaces.data?.workspacesForCurrentUser ?? [];
+  const activeWorkspace =
+    workspaceRows.find((workspace) => workspace.id === selectedWorkspaceId) ?? workspaceRows[0];
   const providers = useQuery<ProviderProfilesData>(PROVIDER_PROFILES_QUERY, {
     variables: { workspaceId: activeWorkspace?.id ?? "" },
     skip: !activeWorkspace
@@ -345,6 +348,20 @@ version: 0.1.0
           <div>
             <p className="eyebrow">{currentUserName}</p>
             <h1>{activeWorkspace?.name ?? "Workspace setup"}</h1>
+            {workspaceRows.length > 1 ? (
+              <select
+                aria-label="Active workspace"
+                className="workspace-select"
+                value={activeWorkspace?.id ?? ""}
+                onChange={(event) => setSelectedWorkspaceId(event.target.value)}
+              >
+                {workspaceRows.map((workspace) => (
+                  <option key={workspace.id} value={workspace.id}>
+                    {workspace.name}
+                  </option>
+                ))}
+              </select>
+            ) : null}
           </div>
           <div className="topbar-actions">
             <Button className="secondary-button" onClick={handleRegisterPasskey}>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,6 +4,7 @@ import { startAuthentication, startRegistration } from "@simplewebauthn/browser"
 import { Boxes, KeyRound, Settings, Upload, UsersRound } from "lucide-react";
 import { FormEvent, useMemo, useState } from "react";
 import {
+  ADD_WORKSPACE_MEMBER,
   CURRENT_USER_QUERY,
   CREATE_PROVIDER_PROFILE,
   FINISH_PASSKEY_AUTHENTICATION,
@@ -11,10 +12,13 @@ import {
   LOGIN_WITH_PASSWORD,
   LOGOUT,
   PROVIDER_PROFILES_QUERY,
+  REMOVE_WORKSPACE_MEMBER,
   SKILLS_QUERY,
   START_PASSKEY_AUTHENTICATION,
   START_PASSKEY_REGISTRATION,
   UPLOAD_SKILL,
+  UPDATE_WORKSPACE_MEMBER_ROLE,
+  WORKSPACE_MEMBERS_QUERY,
   WORKSPACES_QUERY
 } from "./graphql";
 
@@ -41,6 +45,8 @@ interface Skill {
   status: string;
 }
 
+type WorkspaceRole = "owner" | "admin" | "member" | "viewer";
+
 interface DashboardData {
   currentUser: {
     id: string;
@@ -60,6 +66,19 @@ interface SkillsData {
   skills: Skill[];
 }
 
+interface WorkspaceMember {
+  id: string;
+  workspaceId: string;
+  userId: string;
+  displayName: string;
+  email?: string;
+  role: WorkspaceRole;
+}
+
+interface WorkspaceMembersData {
+  workspaceMembers: WorkspaceMember[];
+}
+
 interface LoggedInUser {
   userId: string;
   displayName: string;
@@ -74,6 +93,8 @@ export function App() {
   const [providerBaseUrl, setProviderBaseUrl] = useState("https://api.example.test/v1");
   const [providerModel, setProviderModel] = useState("gpt-image-test");
   const [providerApiKey, setProviderApiKey] = useState("test-key");
+  const [memberEmail, setMemberEmail] = useState("tester2@example.test");
+  const [memberRole, setMemberRole] = useState<WorkspaceRole>("member");
   const [skillMd, setSkillMd] = useState(`---
 name: studio-image-style
 description: Creates images in the workspace house style.
@@ -95,6 +116,9 @@ version: 0.1.0
   const [finishPasskeyAuthenticationMutation] = useMutation(FINISH_PASSKEY_AUTHENTICATION);
   const [createProviderProfile, providerMutation] = useMutation(CREATE_PROVIDER_PROFILE);
   const [uploadSkill, skillMutation] = useMutation(UPLOAD_SKILL);
+  const [addWorkspaceMember, addMemberMutation] = useMutation(ADD_WORKSPACE_MEMBER);
+  const [updateWorkspaceMemberRole, updateMemberMutation] = useMutation(UPDATE_WORKSPACE_MEMBER_ROLE);
+  const [removeWorkspaceMember, removeMemberMutation] = useMutation(REMOVE_WORKSPACE_MEMBER);
   const currentUser = currentUserQuery.data?.currentUser;
   const workspaces = useQuery<WorkspacesData>(WORKSPACES_QUERY, {
     skip: !currentUser
@@ -108,12 +132,18 @@ version: 0.1.0
     variables: { workspaceId: activeWorkspace?.id ?? "" },
     skip: !activeWorkspace
   });
+  const members = useQuery<WorkspaceMembersData>(WORKSPACE_MEMBERS_QUERY, {
+    variables: { workspaceId: activeWorkspace?.id ?? "" },
+    skip: !activeWorkspace
+  });
 
   const providerRows = providers.data?.providerProfiles ?? [];
   const skillRows = skills.data?.skills ?? [];
+  const memberRows = members.data?.workspaceMembers ?? [];
   const currentUserName = currentUser?.displayName ?? "Loading user";
   const loginError = loginState.error?.message;
   const providerError = providerMutation.error?.message;
+  const memberError = addMemberMutation.error?.message ?? updateMemberMutation.error?.message ?? removeMemberMutation.error?.message;
   const skillResult = skillMutation.data?.uploadSkill;
   const skillErrors = useMemo(() => skillResult?.version.validationErrors ?? [], [skillResult]);
 
@@ -202,6 +232,37 @@ version: 0.1.0
         }
       },
       refetchQueries: [{ query: SKILLS_QUERY, variables: { workspaceId: activeWorkspace.id } }]
+    });
+  }
+
+  async function handleMemberSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!activeWorkspace) return;
+    await addWorkspaceMember({
+      variables: {
+        input: {
+          workspaceId: activeWorkspace.id,
+          email: memberEmail,
+          role: memberRole
+        }
+      },
+      refetchQueries: [{ query: WORKSPACE_MEMBERS_QUERY, variables: { workspaceId: activeWorkspace.id } }]
+    });
+  }
+
+  async function handleRoleChange(membershipId: string, role: WorkspaceRole) {
+    if (!activeWorkspace) return;
+    await updateWorkspaceMemberRole({
+      variables: { input: { membershipId, role } },
+      refetchQueries: [{ query: WORKSPACE_MEMBERS_QUERY, variables: { workspaceId: activeWorkspace.id } }]
+    });
+  }
+
+  async function handleRemoveMember(membershipId: string) {
+    if (!activeWorkspace) return;
+    await removeWorkspaceMember({
+      variables: { membershipId },
+      refetchQueries: [{ query: WORKSPACE_MEMBERS_QUERY, variables: { workspaceId: activeWorkspace.id } }]
     });
   }
 
@@ -395,20 +456,51 @@ version: 0.1.0
                 <p>Shared resources are scoped by membership.</p>
               </div>
             </div>
-            <div className="metric-list">
-              <div>
-                <span>Members</span>
-                <strong>1</strong>
-              </div>
-              <div>
-                <span>Roles</span>
-                <strong>4</strong>
-              </div>
-              <div>
-                <span>Secret exposure</span>
-                <strong>Redacted</strong>
-              </div>
+            <div className="member-list">
+              {memberRows.map((member) => (
+                <article className="member-item" key={member.id}>
+                  <div>
+                    <strong>{member.displayName}</strong>
+                    <span>{member.email ?? member.userId}</span>
+                  </div>
+                  <select
+                    aria-label={`Role for ${member.displayName}`}
+                    value={member.role}
+                    onChange={(event) => handleRoleChange(member.id, event.target.value as WorkspaceRole)}
+                  >
+                    <option value="owner">owner</option>
+                    <option value="admin">admin</option>
+                    <option value="member">member</option>
+                    <option value="viewer">viewer</option>
+                  </select>
+                  <Button className="secondary-button" onClick={() => handleRemoveMember(member.id)}>
+                    Remove
+                  </Button>
+                </article>
+              ))}
             </div>
+            <form className="stacked-form" onSubmit={handleMemberSubmit}>
+              <label>
+                Member email
+                <input value={memberEmail} onChange={(event) => setMemberEmail(event.target.value)} />
+              </label>
+              <label>
+                Role
+                <select
+                  aria-label="New member role"
+                  value={memberRole}
+                  onChange={(event) => setMemberRole(event.target.value as WorkspaceRole)}
+                >
+                  <option value="admin">admin</option>
+                  <option value="member">member</option>
+                  <option value="viewer">viewer</option>
+                </select>
+              </label>
+              {memberError ? <p className="error-text">{memberError}</p> : null}
+              <Button className="primary-button" type="submit">
+                Add Member
+              </Button>
+            </form>
           </section>
         </div>
       </section>

--- a/apps/web/src/graphql.ts
+++ b/apps/web/src/graphql.ts
@@ -20,6 +20,19 @@ export const WORKSPACES_QUERY = gql`
   }
 `;
 
+export const WORKSPACE_MEMBERS_QUERY = gql`
+  query WorkspaceMembers($workspaceId: String!) {
+    workspaceMembers(workspaceId: $workspaceId) {
+      id
+      workspaceId
+      userId
+      displayName
+      email
+      role
+    }
+  }
+`;
+
 export const LOGOUT = gql`
   mutation Logout {
     logout
@@ -118,6 +131,32 @@ export const CREATE_PROVIDER_PROFILE = gql`
       capabilities
       hasApiKey
     }
+  }
+`;
+
+export const ADD_WORKSPACE_MEMBER = gql`
+  mutation AddWorkspaceMember($input: AddWorkspaceMemberInput!) {
+    addWorkspaceMember(input: $input) {
+      id
+      displayName
+      email
+      role
+    }
+  }
+`;
+
+export const UPDATE_WORKSPACE_MEMBER_ROLE = gql`
+  mutation UpdateWorkspaceMemberRole($input: UpdateWorkspaceMemberRoleInput!) {
+    updateWorkspaceMemberRole(input: $input) {
+      id
+      role
+    }
+  }
+`;
+
+export const REMOVE_WORKSPACE_MEMBER = gql`
+  mutation RemoveWorkspaceMember($membershipId: String!) {
+    removeWorkspaceMember(membershipId: $membershipId)
   }
 `;
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15,6 +15,7 @@ body {
 }
 
 input,
+select,
 textarea {
   width: 100%;
   border: 1px solid #ccd8d2;
@@ -259,6 +260,7 @@ button {
 }
 
 .skill-list,
+.member-list,
 .metric-list {
   display: grid;
   gap: 10px;
@@ -293,14 +295,24 @@ button {
 }
 
 .skill-item,
+.member-item,
 .metric-list > div {
   border: 1px solid #e2e9e5;
   border-radius: 8px;
   padding: 12px;
 }
 
+.member-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 106px auto;
+  align-items: center;
+  gap: 10px;
+}
+
 .skill-item strong,
 .skill-item span,
+.member-item strong,
+.member-item span,
 .metric-list span,
 .metric-list strong {
   display: block;
@@ -346,5 +358,9 @@ button {
     grid-template-columns: 1fr;
     gap: 4px;
     padding: 12px;
+  }
+
+  .member-item {
+    grid-template-columns: 1fr;
   }
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -161,6 +161,11 @@ button {
   font-size: 2rem;
 }
 
+.workspace-select {
+  margin-top: 8px;
+  max-width: 280px;
+}
+
 .eyebrow {
   margin: 0 0 4px;
 }

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -115,9 +115,11 @@ test.describe("foundation workspace flows", () => {
     await page.getByRole("button", { name: "Add Member" }).click();
     await expect(page.getByText(accounts[1].displayName)).toBeVisible();
     await expect(page.getByLabel(`Role for ${accounts[1].displayName}`)).toHaveValue("member");
+    const ownerWorkspaceId = await currentWorkspaceId(page);
 
     await signOut(page);
     await login(page, accounts[1]);
+    await page.getByLabel("Active workspace").selectOption(ownerWorkspaceId);
     await expect(page.getByRole("heading", { name: "Personal Workspace" })).toBeVisible();
     await expect(page.locator(".member-item").filter({ hasText: accounts[0].displayName })).toBeVisible();
 
@@ -188,3 +190,18 @@ version: 2.0.0
     await expect(page.getByText("SKILL.md frontmatter must include description")).toBeVisible();
   });
 });
+
+async function currentWorkspaceId(page: Page): Promise<string> {
+  return page.evaluate(async () => {
+    const response = await fetch("http://localhost:4000/graphql", {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        query: "{ workspacesForCurrentUser { id } }"
+      })
+    });
+    const json = await response.json();
+    return json.data.workspacesForCurrentUser[0].id as string;
+  });
+}

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -14,8 +14,13 @@ async function login(page: Page, account = accounts[0]) {
   await page.getByLabel("Email").fill(account.email);
   await page.getByLabel("Password").fill(account.password);
   await page.getByRole("button", { name: "Sign in", exact: true }).click();
-  await expect(page.getByText(account.displayName)).toBeVisible();
+  await expect(page.locator(".topbar .eyebrow")).toHaveText(account.displayName);
   await expect(page.getByRole("heading", { name: "Personal Workspace" })).toBeVisible();
+}
+
+async function signOut(page: Page) {
+  await page.getByRole("button", { name: "Sign out" }).click();
+  await expect(page.getByRole("heading", { name: "Gen Image Studio" })).toBeVisible();
 }
 
 async function resetBrowserState(page: Page) {
@@ -51,7 +56,7 @@ test.describe("foundation workspace flows", () => {
     await login(page);
 
     await page.reload();
-    await expect(page.getByText(accounts[0].displayName)).toBeVisible();
+    await expect(page.locator(".topbar .eyebrow")).toHaveText(accounts[0].displayName);
     await page.getByRole("button", { name: "Sign out" }).click();
     await expect(page.getByRole("heading", { name: "Gen Image Studio" })).toBeVisible();
 
@@ -62,15 +67,14 @@ test.describe("foundation workspace flows", () => {
   test("does not leak cached workspace data when switching users", async ({ page }) => {
     await resetBrowserState(page);
     await login(page, accounts[0]);
-    await expect(page.getByText(accounts[0].displayName)).toBeVisible();
+    await expect(page.locator(".topbar .eyebrow")).toHaveText(accounts[0].displayName);
 
     await page.getByRole("button", { name: "Sign out" }).click();
     await page.getByLabel("Email").fill(accounts[1].email);
     await page.getByLabel("Password").fill(accounts[1].password);
     await page.getByRole("button", { name: "Sign in", exact: true }).click();
 
-    await expect(page.getByText(accounts[1].displayName)).toBeVisible();
-    await expect(page.getByText(accounts[0].displayName)).toHaveCount(0);
+    await expect(page.locator(".topbar .eyebrow")).toHaveText(accounts[1].displayName);
     const workspaceIds = await page.evaluate(async () => {
       const response = await fetch("http://localhost:4000/graphql", {
         method: "POST",
@@ -96,8 +100,41 @@ test.describe("foundation workspace flows", () => {
     await page.getByRole("button", { name: "Sign out" }).click();
 
     await page.getByRole("button", { name: "Sign in with passkey" }).click();
-    await expect(page.getByText(accounts[0].displayName)).toBeVisible();
+    await expect(page.locator(".topbar .eyebrow")).toHaveText(accounts[0].displayName);
     await expect(page.getByRole("heading", { name: "Personal Workspace" })).toBeVisible();
+  });
+
+  test("lets an owner add, update, and remove a workspace collaborator", async ({ page }) => {
+    await resetBrowserState(page);
+    await login(page, accounts[1]);
+    await signOut(page);
+    await login(page, accounts[0]);
+
+    await page.getByLabel("Member email").fill(accounts[1].email);
+    await page.getByLabel("New member role").selectOption("member");
+    await page.getByRole("button", { name: "Add Member" }).click();
+    await expect(page.getByText(accounts[1].displayName)).toBeVisible();
+    await expect(page.getByLabel(`Role for ${accounts[1].displayName}`)).toHaveValue("member");
+
+    await signOut(page);
+    await login(page, accounts[1]);
+    await expect(page.getByRole("heading", { name: "Personal Workspace" })).toBeVisible();
+    await expect(page.locator(".member-item").filter({ hasText: accounts[0].displayName })).toBeVisible();
+
+    await page.getByLabel("Member email").fill(accounts[2].email);
+    await page.getByRole("button", { name: "Add Member" }).click();
+    await expect(page.getByText("User cannot manage workspace members")).toBeVisible();
+
+    await signOut(page);
+    await login(page, accounts[0]);
+    await page.getByLabel(`Role for ${accounts[1].displayName}`).selectOption("viewer");
+    await expect(page.getByLabel(`Role for ${accounts[1].displayName}`)).toHaveValue("viewer");
+    await page.locator(".member-item").filter({ hasText: accounts[1].displayName }).getByRole("button", { name: "Remove" }).click();
+    await expect(page.locator(".member-item").filter({ hasText: accounts[1].displayName })).toHaveCount(0);
+
+    await signOut(page);
+    await login(page, accounts[1]);
+    await expect(page.locator(".member-item").filter({ hasText: accounts[0].displayName })).toHaveCount(0);
   });
 
   test("rejects invalid password login", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Closes #7 by adding existing-user workspace member add, role update, remove, and display-ready member listing.
- Enforces owner/admin member-management permissions, protects the last owner from demotion or removal, and avoids duplicate-add role demotion.
- Adds Workspace Access controls plus an active workspace selector so collaborators can open shared workspaces.
- Expands Playwright e2e to cover owner-managed collaboration, shared workspace selection, unauthorized member management, role update, removal, and access loss.

## Linked Issue

Closes #7

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gen-image-studio/issues/7#issuecomment-4349397198

## Validation

- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:e2e

