### PR TITLE
Persist uploaded Agent Skill files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ dist/
 build/
 .vite/
 coverage/
+.data/
+apps/**/.data/
 .env
 .env.*
 !.env.example

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,10 +1,15 @@
 import "reflect-metadata";
 import { Logger } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
+import { NestExpressApplication } from "@nestjs/platform-express";
 import { AppModule } from "./app.module";
 
+const uploadBodyLimit = "1mb";
+
 async function bootstrap(): Promise<void> {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, { bodyParser: false });
+  app.useBodyParser("json", { limit: uploadBodyLimit });
+  app.useBodyParser("urlencoded", { extended: true, limit: uploadBodyLimit });
   const webOrigin = process.env.WEB_ORIGIN ?? "http://localhost:5173";
   app.enableCors({
     origin: webOrigin,
@@ -17,4 +22,3 @@ async function bootstrap(): Promise<void> {
 }
 
 void bootstrap();
-

--- a/apps/api/src/skills/skill.types.ts
+++ b/apps/api/src/skills/skill.types.ts
@@ -20,9 +20,6 @@ export class SkillUploadInput {
   @Field()
   contentBase64: string;
 
-  @Field()
-  skillMdContent: string;
-
   @Field(() => [String], { defaultValue: [] })
   permissions: string[];
 }

--- a/apps/api/src/skills/skill.types.ts
+++ b/apps/api/src/skills/skill.types.ts
@@ -9,6 +9,18 @@ export class SkillUploadInput {
   archiveSha256: string;
 
   @Field()
+  fileName: string;
+
+  @Field()
+  mimeType: string;
+
+  @Field()
+  byteSize: number;
+
+  @Field()
+  contentBase64: string;
+
+  @Field()
   skillMdContent: string;
 
   @Field(() => [String], { defaultValue: [] })
@@ -80,4 +92,3 @@ export class SkillUploadResult {
   @Field(() => SkillVersion)
   version: SkillVersion;
 }
-

--- a/apps/api/src/skills/skills.service.ts
+++ b/apps/api/src/skills/skills.service.ts
@@ -125,6 +125,9 @@ export class SkillsService {
     if (input.contentBase64.length > Math.ceil(maxSkillUploadBytes / 3) * 4 + 4) {
       throw new BadRequestException("Skill upload exceeds the 256KB limit");
     }
+    if (!this.isCanonicalBase64(input.contentBase64)) {
+      throw new BadRequestException("Skill upload content must be canonical base64");
+    }
     const bytes = Buffer.from(input.contentBase64, "base64");
     if (bytes.length > maxSkillUploadBytes) {
       throw new BadRequestException("Skill upload exceeds the 256KB limit");
@@ -147,6 +150,13 @@ export class SkillsService {
       mimeType: "text/markdown",
       sha256
     };
+  }
+
+  private isCanonicalBase64(value: string): boolean {
+    if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+      return false;
+    }
+    return Buffer.from(value, "base64").toString("base64") === value;
   }
 
   private async writeSkillArchive(storagePath: string, bytes: Buffer): Promise<void> {

--- a/apps/api/src/skills/skills.service.ts
+++ b/apps/api/src/skills/skills.service.ts
@@ -1,6 +1,8 @@
-import { Injectable } from "@nestjs/common";
+import { BadRequestException, Injectable } from "@nestjs/common";
 import { Inject } from "@nestjs/common";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { eq } from "drizzle-orm";
 import { DB } from "../db/db.module";
 import { assets, skills, skillVersions } from "../db/schema";
@@ -8,6 +10,8 @@ import { AppDb } from "../db/types";
 import { WorkspacesService } from "../workspaces/workspaces.service";
 import { parseSkillMd } from "./skill-md.parser";
 import { Skill, SkillUploadInput, SkillUploadResult, SkillVersion } from "./skill.types";
+
+const maxSkillUploadBytes = 256 * 1024;
 
 @Injectable()
 export class SkillsService {
@@ -24,8 +28,12 @@ export class SkillsService {
 
   async upload(input: SkillUploadInput, userId: string): Promise<SkillUploadResult> {
     await this.assertWorkspaceMember(input.workspaceId, userId);
-    const parsed = parseSkillMd(input.skillMdContent);
+    const file = this.decodeUpload(input);
+    const skillMdContent = file.bytes.toString("utf8");
+    const parsed = parseSkillMd(skillMdContent);
     const name = parsed.name || "Invalid Skill";
+    const storagePath = `skill-archives/${file.sha256}.md`;
+    await this.writeSkillArchive(storagePath, file.bytes);
     const result = await this.db.transaction(async (tx) => {
       const [archiveAsset] = await tx
         .insert(assets)
@@ -33,10 +41,10 @@ export class SkillsService {
           workspaceId: input.workspaceId,
           ownerId: userId,
           kind: "skill-archive",
-          mimeType: "text/markdown",
-          byteSize: Buffer.byteLength(input.skillMdContent),
-          sha256: input.archiveSha256,
-          storagePath: `skill-archives/${input.archiveSha256}`
+          mimeType: file.mimeType,
+          byteSize: file.bytes.length,
+          sha256: file.sha256,
+          storagePath
         })
         .returning();
       if (!archiveAsset) {
@@ -105,6 +113,38 @@ export class SkillsService {
       .replace(/^-|-$/g, "")
       .slice(0, 80);
     return slug || "skill";
+  }
+
+  private decodeUpload(input: SkillUploadInput): { bytes: Buffer; mimeType: string; sha256: string } {
+    const bytes = Buffer.from(input.contentBase64, "base64");
+    if (bytes.length === 0) {
+      throw new BadRequestException("Skill upload file is empty");
+    }
+    if (bytes.length > maxSkillUploadBytes) {
+      throw new BadRequestException("Skill upload exceeds the 256KB limit");
+    }
+    if (bytes.length !== input.byteSize) {
+      throw new BadRequestException("Skill upload byte size does not match the file metadata");
+    }
+    if (!input.fileName.toLowerCase().endsWith(".md")) {
+      throw new BadRequestException("Only .md Agent Skill files are supported");
+    }
+    const sha256 = createHash("sha256").update(bytes).digest("hex");
+    if (sha256 !== input.archiveSha256) {
+      throw new BadRequestException("Skill upload sha256 does not match the file content");
+    }
+    return {
+      bytes,
+      mimeType: input.mimeType || "text/markdown",
+      sha256
+    };
+  }
+
+  private async writeSkillArchive(storagePath: string, bytes: Buffer): Promise<void> {
+    const assetRoot = process.env.ASSET_STORAGE_DIR ?? ".data/assets";
+    const archiveDir = join(assetRoot, "skill-archives");
+    await mkdir(archiveDir, { recursive: true });
+    await writeFile(join(assetRoot, storagePath), bytes);
   }
 
   private async assertWorkspaceMember(workspaceId: string, userId: string): Promise<void> {

--- a/apps/api/src/skills/skills.service.ts
+++ b/apps/api/src/skills/skills.service.ts
@@ -41,7 +41,7 @@ export class SkillsService {
           workspaceId: input.workspaceId,
           ownerId: userId,
           kind: "skill-archive",
-          mimeType: file.mimeType,
+          mimeType: "text/markdown",
           byteSize: file.bytes.length,
           sha256: file.sha256,
           storagePath
@@ -116,10 +116,16 @@ export class SkillsService {
   }
 
   private decodeUpload(input: SkillUploadInput): { bytes: Buffer; mimeType: string; sha256: string } {
-    const bytes = Buffer.from(input.contentBase64, "base64");
-    if (bytes.length === 0) {
-      throw new BadRequestException("Skill upload file is empty");
+    if (!Number.isSafeInteger(input.byteSize) || input.byteSize <= 0) {
+      throw new BadRequestException("Skill upload byte size must be a positive integer");
     }
+    if (input.byteSize > maxSkillUploadBytes) {
+      throw new BadRequestException("Skill upload exceeds the 256KB limit");
+    }
+    if (input.contentBase64.length > Math.ceil(maxSkillUploadBytes / 3) * 4 + 4) {
+      throw new BadRequestException("Skill upload exceeds the 256KB limit");
+    }
+    const bytes = Buffer.from(input.contentBase64, "base64");
     if (bytes.length > maxSkillUploadBytes) {
       throw new BadRequestException("Skill upload exceeds the 256KB limit");
     }
@@ -129,13 +135,16 @@ export class SkillsService {
     if (!input.fileName.toLowerCase().endsWith(".md")) {
       throw new BadRequestException("Only .md Agent Skill files are supported");
     }
+    if (input.mimeType && !["text/markdown", "text/plain", "application/octet-stream"].includes(input.mimeType)) {
+      throw new BadRequestException("Skill upload MIME type must be markdown or plain text");
+    }
     const sha256 = createHash("sha256").update(bytes).digest("hex");
     if (sha256 !== input.archiveSha256) {
       throw new BadRequestException("Skill upload sha256 does not match the file content");
     }
     return {
       bytes,
-      mimeType: input.mimeType || "text/markdown",
+      mimeType: "text/markdown",
       sha256
     };
   }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -231,7 +231,6 @@ export function App() {
           mimeType: skillFile.type || "text/markdown",
           byteSize: skillFile.size,
           contentBase64,
-          skillMdContent: "",
           permissions: ["use-provider", "write-workspace-assets"]
         }
       },

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -96,14 +96,7 @@ export function App() {
   const [memberEmail, setMemberEmail] = useState("tester2@example.test");
   const [memberRole, setMemberRole] = useState<WorkspaceRole>("member");
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
-  const [skillMd, setSkillMd] = useState(`---
-name: studio-image-style
-description: Creates images in the workspace house style.
-version: 0.1.0
----
-
-# Studio Image Style
-`);
+  const [skillFile, setSkillFile] = useState<File | null>(null);
   const [loginMessage, setLoginMessage] = useState<string | null>(null);
   const [passkeyMessage, setPasskeyMessage] = useState<string | null>(null);
   const currentUserQuery = useQuery<DashboardData>(CURRENT_USER_QUERY, {
@@ -224,13 +217,21 @@ version: 0.1.0
 
   async function handleSkillSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!activeWorkspace) return;
+    if (!activeWorkspace || !skillFile) return;
+    const fileBuffer = await skillFile.arrayBuffer();
+    const bytes = new Uint8Array(fileBuffer);
+    const archiveSha256 = await sha256Hex(fileBuffer);
+    const contentBase64 = bytesToBase64(bytes);
     await uploadSkill({
       variables: {
         input: {
           workspaceId: activeWorkspace.id,
-          archiveSha256: "e2e-skill-archive",
-          skillMdContent: skillMd,
+          archiveSha256,
+          fileName: skillFile.name,
+          mimeType: skillFile.type || "text/markdown",
+          byteSize: skillFile.size,
+          contentBase64,
+          skillMdContent: "",
           permissions: ["use-provider", "write-workspace-assets"]
         }
       },
@@ -452,8 +453,12 @@ version: 0.1.0
             </div>
             <form className="stacked-form" onSubmit={handleSkillSubmit}>
               <label>
-                SKILL.md
-                <textarea value={skillMd} onChange={(event) => setSkillMd(event.target.value)} rows={8} />
+                SKILL.md file
+                <input
+                  type="file"
+                  accept=".md,text/markdown,text/plain"
+                  onChange={(event) => setSkillFile(event.target.files?.[0] ?? null)}
+                />
               </label>
               {skillResult ? (
                 <p className={skillErrors.length > 0 ? "error-text" : "success-text"}>
@@ -461,7 +466,7 @@ version: 0.1.0
                 </p>
               ) : null}
               <Button className="primary-button" type="submit">
-                Validate Skill
+                Upload Skill
               </Button>
             </form>
           </section>
@@ -523,4 +528,17 @@ version: 0.1.0
       </section>
     </main>
   );
+}
+
+async function sha256Hex(bytes: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
 }

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -194,6 +194,41 @@ version: 2.0.0
     await expect(page.getByText("SKILL.md frontmatter must include name")).toBeVisible();
     await expect(page.getByText("SKILL.md frontmatter must include description")).toBeVisible();
   });
+
+  test("rejects skill uploads with invalid archive metadata", async ({ page }) => {
+    await login(page);
+    const workspaceId = await currentWorkspaceId(page);
+    const filePath = await writeSkillFile("tampered-skill.md", `---
+name: tampered-skill
+description: Hash mismatch check.
+---
+
+# Tampered Skill
+`);
+    const bytes = await readFile(filePath);
+    const contentBase64 = bytes.toString("base64");
+
+    const mismatch = await uploadSkillViaGraphql(page, {
+      workspaceId,
+      archiveSha256: "0".repeat(64),
+      fileName: "tampered-skill.md",
+      mimeType: "text/markdown",
+      byteSize: bytes.length,
+      contentBase64
+    });
+    expect(mismatch.errors?.[0]?.message).toContain("sha256");
+
+    const oversizedBytes = Buffer.from("small body with oversized metadata");
+    const oversized = await uploadSkillViaGraphql(page, {
+      workspaceId,
+      archiveSha256: createHash("sha256").update(oversizedBytes).digest("hex"),
+      fileName: "oversized-skill.md",
+      mimeType: "text/markdown",
+      byteSize: 256 * 1024 + 1,
+      contentBase64: oversizedBytes.toString("base64")
+    });
+    expect(oversized.errors?.[0]?.message).toContain("256KB");
+  });
 });
 
 async function currentWorkspaceId(page: Page): Promise<string> {
@@ -224,4 +259,38 @@ async function expectStoredSkillArchive(filePath: string): Promise<void> {
   const sha256 = createHash("sha256").update(bytes).digest("hex");
   const storedBytes = await readFile(join(process.cwd(), "apps/api/.data/assets/skill-archives", `${sha256}.md`));
   expect(storedBytes.equals(bytes)).toBe(true);
+}
+
+async function uploadSkillViaGraphql(
+  page: Page,
+  input: {
+    workspaceId: string;
+    archiveSha256: string;
+    fileName: string;
+    mimeType: string;
+    byteSize: number;
+    contentBase64: string;
+  }
+): Promise<{ errors?: { message: string }[] }> {
+  return page.evaluate(async (uploadInput) => {
+    const response = await fetch("http://localhost:4000/graphql", {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        query: `mutation UploadSkill($input: SkillUploadInput!) {
+          uploadSkill(input: $input) {
+            skill { id }
+          }
+        }`,
+        variables: {
+          input: {
+            ...uploadInput,
+            permissions: []
+          }
+        }
+      })
+    });
+    return response.json();
+  }, input);
 }

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -1,4 +1,7 @@
 import { expect, Page, test } from "@playwright/test";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 
 const accounts = [
   { email: "tester1@example.test", password: "test-password-1", displayName: "Tester 1" },
@@ -162,10 +165,9 @@ test.describe("foundation workspace flows", () => {
     await expect(page.getByText("super-secret-e2e-key")).toHaveCount(0);
   });
 
-  test("indexes a valid Agent Skill from SKILL.md content", async ({ page }) => {
+  test("indexes a valid Agent Skill from an uploaded SKILL.md file", async ({ page }) => {
     await login(page);
-
-    await page.getByLabel("SKILL.md").fill(`---
+    const filePath = await writeSkillFile("valid-skill.md", `---
 name: e2e-image-skill
 description: Generates images for the Playwright flow.
 version: 2.0.0
@@ -173,17 +175,20 @@ version: 2.0.0
 
 # E2E Image Skill
 `);
-    await page.getByRole("button", { name: "Validate Skill" }).click();
+    await page.getByLabel("SKILL.md file").setInputFiles(filePath);
+    await page.getByRole("button", { name: "Upload Skill" }).click();
 
     await expect(page.getByText("Indexed e2e-image-skill")).toBeVisible();
     await expect(page.locator(".skill-item").filter({ hasText: "e2e-image-skill" })).toBeVisible();
+    await expectStoredSkillArchive(filePath);
   });
 
-  test("shows validation errors for invalid Agent Skill content", async ({ page }) => {
+  test("shows validation errors for an invalid Agent Skill file", async ({ page }) => {
     await login(page);
+    const filePath = await writeSkillFile("invalid-skill.md", "# No frontmatter here");
 
-    await page.getByLabel("SKILL.md").fill("# No frontmatter here");
-    await page.getByRole("button", { name: "Validate Skill" }).click();
+    await page.getByLabel("SKILL.md file").setInputFiles(filePath);
+    await page.getByRole("button", { name: "Upload Skill" }).click();
 
     await expect(page.getByText("SKILL.md must start with YAML frontmatter")).toBeVisible();
     await expect(page.getByText("SKILL.md frontmatter must include name")).toBeVisible();
@@ -204,4 +209,19 @@ async function currentWorkspaceId(page: Page): Promise<string> {
     const json = await response.json();
     return json.data.workspacesForCurrentUser[0].id as string;
   });
+}
+
+async function writeSkillFile(name: string, content: string): Promise<string> {
+  const dir = join(process.cwd(), "test-results", "skill-fixtures");
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, name);
+  await writeFile(path, content);
+  return path;
+}
+
+async function expectStoredSkillArchive(filePath: string): Promise<void> {
+  const bytes = await readFile(filePath);
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  const storedBytes = await readFile(join(process.cwd(), "apps/api/.data/assets/skill-archives", `${sha256}.md`));
+  expect(storedBytes.equals(bytes)).toBe(true);
 }

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -228,6 +228,17 @@ description: Hash mismatch check.
       contentBase64: oversizedBytes.toString("base64")
     });
     expect(oversized.errors?.[0]?.message).toContain("256KB");
+
+    const base64Bytes = Buffer.from("valid bytes with invalid base64 wrapper");
+    const invalidBase64 = await uploadSkillViaGraphql(page, {
+      workspaceId,
+      archiveSha256: createHash("sha256").update(base64Bytes).digest("hex"),
+      fileName: "invalid-base64-skill.md",
+      mimeType: "text/markdown",
+      byteSize: base64Bytes.length,
+      contentBase64: `${base64Bytes.toString("base64")}!!!!`
+    });
+    expect(invalidBase64.errors?.[0]?.message).toContain("canonical base64");
   });
 });
 

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -195,6 +195,32 @@ version: 2.0.0
     await expect(page.getByText("SKILL.md frontmatter must include description")).toBeVisible();
   });
 
+  test("accepts a valid Agent Skill upload above the default JSON body limit", async ({ page }) => {
+    await login(page);
+    const workspaceId = await currentWorkspaceId(page);
+    const filePath = await writeSkillFile("large-valid-skill.md", `---
+name: large-valid-skill
+description: Valid upload that exercises GraphQL body parser limits.
+---
+
+# Large Valid Skill
+
+${"A".repeat(192 * 1024)}
+`);
+    const bytes = await readFile(filePath);
+    const upload = await uploadSkillViaGraphql(page, {
+      workspaceId,
+      archiveSha256: createHash("sha256").update(bytes).digest("hex"),
+      fileName: "large-valid-skill.md",
+      mimeType: "text/markdown",
+      byteSize: bytes.length,
+      contentBase64: bytes.toString("base64")
+    });
+    expect(upload.errors).toBeUndefined();
+    expect(upload.data?.uploadSkill.skill.id).toBeTruthy();
+    await expectStoredSkillArchive(filePath);
+  });
+
   test("rejects skill uploads with invalid archive metadata", async ({ page }) => {
     await login(page);
     const workspaceId = await currentWorkspaceId(page);
@@ -282,7 +308,7 @@ async function uploadSkillViaGraphql(
     byteSize: number;
     contentBase64: string;
   }
-): Promise<{ errors?: { message: string }[] }> {
+): Promise<{ data?: { uploadSkill: { skill: { id: string } } }; errors?: { message: string }[] }> {
   return page.evaluate(async (uploadInput) => {
     const response = await fetch("http://localhost:4000/graphql", {
       method: "POST",


### PR DESCRIPTION
## Summary

- Closes #9 by replacing textarea skill upload with real SKILL.md file selection and browser-side sha256 metadata.
- Persists uploaded skill bytes under local asset storage after server-side pre-decode size checks, canonical base64 validation, sha256 validation, MIME normalization, and explicit GraphQL body parser limits for larger valid uploads.
- Stores asset rows with actual upload metadata and ignores runtime .data asset output.
- Expands Playwright e2e to upload valid and invalid skill files, verify stored archive bytes, and cover rejected sha256, oversized metadata, invalid base64 uploads, and valid payloads above the default JSON body limit.

## Linked Issue

Closes #9

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gen-image-studio/issues/9#issuecomment-4349485788

## Validation

- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:e2e

