### PR TITLE
Run image generation jobs from uploaded Agent Skills

### DIFF
--- a/apps/api/src/ai/ai.module.ts
+++ b/apps/api/src/ai/ai.module.ts
@@ -1,11 +1,11 @@
 import { Module } from "@nestjs/common";
 import { ProviderProfilesModule } from "../provider-profiles/provider-profiles.module";
 import { AiProviderFactory } from "./ai-provider.factory";
+import { ResponsesImageClient } from "./responses-image.client";
 
 @Module({
   imports: [ProviderProfilesModule],
-  providers: [AiProviderFactory],
-  exports: [AiProviderFactory]
+  providers: [AiProviderFactory, ResponsesImageClient],
+  exports: [AiProviderFactory, ResponsesImageClient]
 })
 export class AiModule {}
-

--- a/apps/api/src/ai/responses-image.client.ts
+++ b/apps/api/src/ai/responses-image.client.ts
@@ -118,11 +118,38 @@ export class ResponsesImageClient {
       ].filter(Boolean);
       throw new ImageGenerationTransportError(details.join(" "), true);
     }
+    if (!this.isCanonicalBase64(resultBase64)) {
+      throw new ImageGenerationTransportError("Image generation result must be canonical base64.", false);
+    }
+    const imageBytes = Buffer.from(resultBase64, "base64");
+    if (!this.isSupportedImage(imageBytes)) {
+      throw new ImageGenerationTransportError("Image generation result was not a supported image payload.", false);
+    }
 
     return {
-      imageBytes: Buffer.from(resultBase64, "base64"),
+      imageBytes,
       seenEvents
     };
+  }
+
+  private isCanonicalBase64(value: string): boolean {
+    if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+      return false;
+    }
+    return Buffer.from(value, "base64").toString("base64") === value;
+  }
+
+  private isSupportedImage(bytes: Buffer): boolean {
+    if (bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+      return true;
+    }
+    if (bytes.subarray(0, 3).equals(Buffer.from([0xff, 0xd8, 0xff]))) {
+      return true;
+    }
+    if (bytes.subarray(0, 6).toString("ascii") === "GIF87a" || bytes.subarray(0, 6).toString("ascii") === "GIF89a") {
+      return true;
+    }
+    return bytes.subarray(0, 4).toString("ascii") === "RIFF" && bytes.subarray(8, 12).toString("ascii") === "WEBP";
   }
 
   private parseJsonEvent(data: string): Record<string, unknown> | undefined {

--- a/apps/api/src/ai/responses-image.client.ts
+++ b/apps/api/src/ai/responses-image.client.ts
@@ -1,0 +1,159 @@
+import { Injectable } from "@nestjs/common";
+
+export class ImageGenerationTransportError extends Error {
+  constructor(
+    message: string,
+    readonly retryable: boolean
+  ) {
+    super(message);
+  }
+}
+
+export interface ResponsesImageRequest {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+  toolModel: string;
+  imageAction: "generate";
+  prompt: string;
+  timeoutMs?: number;
+}
+
+export interface ResponsesImageResult {
+  imageBytes: Buffer;
+  seenEvents: string[];
+}
+
+@Injectable()
+export class ResponsesImageClient {
+  async generateImage(input: ResponsesImageRequest): Promise<ResponsesImageResult> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), input.timeoutMs ?? 600_000);
+    try {
+      const response = await fetch(`${input.baseUrl.replace(/\/$/, "")}/responses`, {
+        method: "POST",
+        signal: controller.signal,
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${input.apiKey}`,
+          accept: "text/event-stream"
+        },
+        body: JSON.stringify({
+          model: input.model,
+          stream: true,
+          input: input.prompt,
+          tools: [
+            {
+              type: "image_generation",
+              model: input.toolModel,
+              action: input.imageAction
+            }
+          ]
+        })
+      });
+
+      const body = await response.text();
+      if (!response.ok) {
+        throw new ImageGenerationTransportError(
+          `Responses request failed with HTTP ${response.status}: ${body}`,
+          response.status >= 500 || [401, 403, 429].includes(response.status)
+        );
+      }
+      return this.parseEventStream(body);
+    } catch (error) {
+      if (error instanceof ImageGenerationTransportError) {
+        throw error;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ImageGenerationTransportError(`Network error during image generation: ${message}`, true);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private parseEventStream(body: string): ResponsesImageResult {
+    let resultBase64: string | undefined;
+    let streamError: string | undefined;
+    const seenEvents: string[] = [];
+
+    for (const line of body.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) {
+        continue;
+      }
+      const data = trimmed.slice(5).trim();
+      if (!data || data === "[DONE]") {
+        continue;
+      }
+      const event = this.parseJsonEvent(data);
+      if (!event) {
+        continue;
+      }
+      const eventType = typeof event.type === "string" ? event.type : undefined;
+      if (eventType) {
+        seenEvents.push(eventType);
+      }
+      if (eventType === "error" || eventType === "response.failed") {
+        streamError = this.summarizeStreamError(event);
+      }
+      const item = this.asRecord(event.item);
+      if (item?.type === "image_generation_call" && typeof item.result === "string") {
+        resultBase64 = item.result;
+      }
+      if (
+        eventType === "response.output_item.done" &&
+        item?.type === "image_generation_call" &&
+        typeof item.result === "string"
+      ) {
+        resultBase64 = item.result;
+        break;
+      }
+    }
+
+    if (!resultBase64) {
+      const details = [
+        "No image payload found in SSE stream.",
+        streamError ? `Upstream error: ${streamError}.` : undefined,
+        seenEvents.length > 0 ? `Seen events: ${seenEvents.slice(0, 30).join(", ")}` : undefined
+      ].filter(Boolean);
+      throw new ImageGenerationTransportError(details.join(" "), true);
+    }
+
+    return {
+      imageBytes: Buffer.from(resultBase64, "base64"),
+      seenEvents
+    };
+  }
+
+  private parseJsonEvent(data: string): Record<string, unknown> | undefined {
+    try {
+      return JSON.parse(data) as Record<string, unknown>;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private asRecord(value: unknown): Record<string, unknown> | undefined {
+    return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+  }
+
+  private summarizeStreamError(event: Record<string, unknown>): string {
+    const error = this.asRecord(event.error);
+    if (error) {
+      const code = typeof error.code === "string" ? error.code : undefined;
+      const message = typeof error.message === "string" ? error.message : undefined;
+      if (code && message) return `${code}: ${message}`;
+      if (code) return code;
+      if (message) return message;
+    }
+    const response = this.asRecord(event.response);
+    if (response) {
+      const status = typeof response.status === "string" ? response.status : undefined;
+      const reason = typeof response.status_details === "string" ? response.status_details : undefined;
+      if (status && reason) return `${status}: ${reason}`;
+      if (status) return status;
+      if (reason) return reason;
+    }
+    return JSON.stringify(event);
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { GraphQLModule } from "@nestjs/graphql";
 import { AiModule } from "./ai/ai.module";
 import { AuthModule } from "./auth/auth.module";
 import { DbModule } from "./db/db.module";
+import { JobsModule } from "./jobs/jobs.module";
 import { ProviderProfilesModule } from "./provider-profiles/provider-profiles.module";
 import { SkillsModule } from "./skills/skills.module";
 import { WorkspacesModule } from "./workspaces/workspaces.module";
@@ -24,7 +25,8 @@ import { WorkspacesModule } from "./workspaces/workspaces.module";
     AuthModule,
     ProviderProfilesModule,
     AiModule,
-    SkillsModule
+    SkillsModule,
+    JobsModule
   ]
 })
 export class AppModule {}

--- a/apps/api/src/jobs/job.types.ts
+++ b/apps/api/src/jobs/job.types.ts
@@ -1,0 +1,91 @@
+import { Field, InputType, Int, ObjectType } from "@nestjs/graphql";
+
+@InputType()
+export class RunImageGenerationJobInput {
+  @Field()
+  workspaceId: string;
+
+  @Field()
+  providerProfileId: string;
+
+  @Field()
+  skillId: string;
+
+  @Field()
+  prompt: string;
+}
+
+@ObjectType()
+export class JobEvent {
+  @Field()
+  id: string;
+
+  @Field()
+  type: string;
+
+  @Field({ nullable: true })
+  message?: string;
+
+  @Field()
+  createdAt: string;
+}
+
+@ObjectType()
+export class JobOutput {
+  @Field()
+  id: string;
+
+  @Field()
+  assetId: string;
+
+  @Field()
+  label: string;
+
+  @Field()
+  mimeType: string;
+
+  @Field(() => Int)
+  byteSize: number;
+
+  @Field()
+  sha256: string;
+
+  @Field()
+  storagePath: string;
+
+  @Field()
+  createdAt: string;
+}
+
+@ObjectType()
+export class GenerationJob {
+  @Field()
+  id: string;
+
+  @Field()
+  workspaceId: string;
+
+  @Field({ nullable: true })
+  skillVersionId?: string;
+
+  @Field({ nullable: true })
+  providerProfileId?: string;
+
+  @Field()
+  status: string;
+
+  @Field()
+  prompt: string;
+
+  @Field()
+  createdAt: string;
+
+  @Field()
+  updatedAt: string;
+
+  @Field(() => [JobEvent])
+  events: JobEvent[];
+
+  @Field(() => [JobOutput])
+  outputs: JobOutput[];
+}

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { AiModule } from "../ai/ai.module";
+import { DbModule } from "../db/db.module";
+import { ProviderProfilesModule } from "../provider-profiles/provider-profiles.module";
+import { WorkspacesModule } from "../workspaces/workspaces.module";
+import { JobsResolver } from "./jobs.resolver";
+import { JobsService } from "./jobs.service";
+
+@Module({
+  imports: [AiModule, DbModule, ProviderProfilesModule, WorkspacesModule],
+  providers: [JobsService, JobsResolver]
+})
+export class JobsModule {}

--- a/apps/api/src/jobs/jobs.resolver.ts
+++ b/apps/api/src/jobs/jobs.resolver.ts
@@ -1,0 +1,26 @@
+import { Args, Context, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { RequestWithHeaders } from "../auth/session";
+import { currentUserId } from "../workspaces/workspaces.resolver";
+import { GenerationJob, RunImageGenerationJobInput } from "./job.types";
+import { JobsService } from "./jobs.service";
+
+@Resolver(() => GenerationJob)
+export class JobsResolver {
+  constructor(private readonly jobsService: JobsService) {}
+
+  @Query(() => [GenerationJob])
+  generationJobs(
+    @Args("workspaceId", { type: () => String }) workspaceId: string,
+    @Context("req") req: RequestWithHeaders
+  ): Promise<GenerationJob[]> {
+    return this.jobsService.list(workspaceId, currentUserId(req));
+  }
+
+  @Mutation(() => GenerationJob)
+  runImageGenerationJob(
+    @Args("input", { type: () => RunImageGenerationJobInput }) input: RunImageGenerationJobInput,
+    @Context("req") req: RequestWithHeaders
+  ): Promise<GenerationJob> {
+    return this.jobsService.runImageGeneration(input, currentUserId(req));
+  }
+}

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -1,0 +1,268 @@
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from "@nestjs/common";
+import { Inject } from "@nestjs/common";
+import { and, desc, eq } from "drizzle-orm";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { ImageGenerationTransportError, ResponsesImageClient } from "../ai/responses-image.client";
+import { DB } from "../db/db.module";
+import { assets, jobEvents, jobs, outputs, skills, skillVersions } from "../db/schema";
+import { AppDb } from "../db/types";
+import { ProviderProfilesService } from "../provider-profiles/provider-profiles.service";
+import { WorkspacesService } from "../workspaces/workspaces.service";
+import { GenerationJob, JobEvent, JobOutput, RunImageGenerationJobInput } from "./job.types";
+
+const imageGenerationTimeoutMs = 600_000;
+const imageGenerationJobInputSchema = z.object({
+  workspaceId: z.string().uuid(),
+  providerProfileId: z.string().uuid(),
+  skillId: z.string().uuid(),
+  prompt: z.string().min(1).max(4000)
+});
+
+@Injectable()
+export class JobsService {
+  constructor(
+    private readonly imageClient: ResponsesImageClient,
+    private readonly providerProfiles: ProviderProfilesService,
+    private readonly workspaces: WorkspacesService,
+    @Inject(DB) private readonly db: AppDb
+  ) {}
+
+  async list(workspaceId: string, userId: string): Promise<GenerationJob[]> {
+    await this.workspaces.assertMember(workspaceId, userId);
+    const rows = await this.db
+      .select()
+      .from(jobs)
+      .where(eq(jobs.workspaceId, workspaceId))
+      .orderBy(desc(jobs.createdAt));
+    return Promise.all(rows.map((row) => this.toJobView(row)));
+  }
+
+  async runImageGeneration(input: RunImageGenerationJobInput, userId: string): Promise<GenerationJob> {
+    const parsed = imageGenerationJobInputSchema.parse({
+      workspaceId: input.workspaceId,
+      providerProfileId: input.providerProfileId,
+      skillId: input.skillId,
+      prompt: input.prompt.trim()
+    });
+    await this.workspaces.assertMember(parsed.workspaceId, userId);
+    const provider = await this.providerProfiles.getStored(parsed.providerProfileId);
+    if (!provider) {
+      throw new NotFoundException("Provider profile not found");
+    }
+    if (provider.workspaceId !== parsed.workspaceId) {
+      throw new ForbiddenException("Provider profile is not in this workspace");
+    }
+    const skill = await this.getLatestValidSkillArchive(parsed.workspaceId, parsed.skillId);
+    const skillMd = await readFile(this.assetPath(skill.asset.storagePath), "utf8");
+    const fullPrompt = this.buildGenerationPrompt(skillMd, parsed.prompt);
+
+    const [job] = await this.db
+      .insert(jobs)
+      .values({
+        workspaceId: parsed.workspaceId,
+        requesterId: userId,
+        skillVersionId: skill.version.id,
+        providerProfileId: provider.id,
+        status: "running",
+        input: {
+          prompt: parsed.prompt,
+          skillId: parsed.skillId,
+          providerProfileId: parsed.providerProfileId,
+          imageAction: "generate"
+        }
+      })
+      .returning();
+    if (!job) {
+      throw new Error("Job creation failed");
+    }
+
+    await this.appendEvent(job.id, "created", "Generation job created");
+    await this.appendEvent(job.id, "started", "Generation request started");
+
+    try {
+      const apiKey = await this.providerProfiles.getApiKey(provider.id);
+      const result = await this.imageClient.generateImage({
+        baseUrl: provider.baseUrl,
+        apiKey,
+        model: provider.defaultModel,
+        toolModel: provider.defaultImageModel ?? provider.defaultModel,
+        imageAction: "generate",
+        prompt: fullPrompt,
+        timeoutMs: imageGenerationTimeoutMs
+      });
+      const outputAsset = await this.writeOutputAsset(parsed.workspaceId, userId, result.imageBytes);
+      await this.db.insert(outputs).values({
+        jobId: job.id,
+        assetId: outputAsset.id,
+        label: "generated-image",
+        metadata: { seenEvents: result.seenEvents }
+      });
+      await this.appendEvent(job.id, "completed", "Generation completed", { seenEvents: result.seenEvents });
+      await this.updateStatus(job.id, "succeeded");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await this.appendEvent(job.id, "failed", message, {
+        retryable: error instanceof ImageGenerationTransportError ? error.retryable : false
+      });
+      await this.updateStatus(job.id, "failed");
+    }
+
+    return this.getJobView(job.id);
+  }
+
+  private async getLatestValidSkillArchive(workspaceId: string, skillId: string) {
+    const [row] = await this.db
+      .select({ skill: skills, version: skillVersions, asset: assets })
+      .from(skills)
+      .innerJoin(skillVersions, eq(skillVersions.id, skills.latestVersionId))
+      .innerJoin(assets, eq(assets.id, skillVersions.archiveAssetId))
+      .where(and(eq(skills.id, skillId), eq(skills.workspaceId, workspaceId)))
+      .limit(1);
+    if (!row) {
+      throw new NotFoundException("Skill not found");
+    }
+    if (row.version.validationStatus !== "valid") {
+      throw new BadRequestException("Skill must have a valid latest version before generation");
+    }
+    return row;
+  }
+
+  private buildGenerationPrompt(skillMd: string, userPrompt: string): string {
+    return [
+      "Use the following Agent Skill instructions for this image generation request.",
+      "",
+      "<skill_md>",
+      skillMd,
+      "</skill_md>",
+      "",
+      "User image request:",
+      userPrompt
+    ].join("\n");
+  }
+
+  private async writeOutputAsset(workspaceId: string, ownerId: string, bytes: Buffer) {
+    const sha256 = createHash("sha256").update(bytes).digest("hex");
+    const mimeType = this.sniffImageMimeType(bytes);
+    const extension = this.extensionForMimeType(mimeType);
+    const storagePath = `output-images/${sha256}.${extension}`;
+    const outputDir = join(this.assetRoot(), "output-images");
+    await mkdir(outputDir, { recursive: true });
+    await writeFile(join(this.assetRoot(), storagePath), bytes);
+    const [asset] = await this.db
+      .insert(assets)
+      .values({
+        workspaceId,
+        ownerId,
+        kind: "output-image",
+        mimeType,
+        byteSize: bytes.length,
+        sha256,
+        storagePath
+      })
+      .returning();
+    if (!asset) {
+      throw new Error("Output asset creation failed");
+    }
+    return asset;
+  }
+
+  private sniffImageMimeType(bytes: Buffer): string {
+    if (bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+      return "image/png";
+    }
+    if (bytes.subarray(0, 3).equals(Buffer.from([0xff, 0xd8, 0xff]))) {
+      return "image/jpeg";
+    }
+    if (bytes.subarray(0, 6).toString("ascii") === "GIF87a" || bytes.subarray(0, 6).toString("ascii") === "GIF89a") {
+      return "image/gif";
+    }
+    if (bytes.subarray(0, 4).toString("ascii") === "RIFF" && bytes.subarray(8, 12).toString("ascii") === "WEBP") {
+      return "image/webp";
+    }
+    return "application/octet-stream";
+  }
+
+  private extensionForMimeType(mimeType: string): string {
+    if (mimeType === "image/jpeg") return "jpg";
+    if (mimeType === "image/gif") return "gif";
+    if (mimeType === "image/webp") return "webp";
+    if (mimeType === "image/png") return "png";
+    return "bin";
+  }
+
+  private async appendEvent(jobId: string, type: "created" | "started" | "completed" | "failed", message: string, data: Record<string, unknown> = {}) {
+    await this.db.insert(jobEvents).values({ jobId, type, message, data });
+  }
+
+  private async updateStatus(jobId: string, status: "succeeded" | "failed") {
+    await this.db.update(jobs).set({ status, updatedAt: new Date() }).where(eq(jobs.id, jobId));
+  }
+
+  private async getJobView(jobId: string): Promise<GenerationJob> {
+    const [job] = await this.db.select().from(jobs).where(eq(jobs.id, jobId)).limit(1);
+    if (!job) {
+      throw new Error("Job not found after generation");
+    }
+    return this.toJobView(job);
+  }
+
+  private async toJobView(row: typeof jobs.$inferSelect): Promise<GenerationJob> {
+    const eventRows = await this.db
+      .select()
+      .from(jobEvents)
+      .where(eq(jobEvents.jobId, row.id))
+      .orderBy(jobEvents.createdAt);
+    const outputRows = await this.db
+      .select({ output: outputs, asset: assets })
+      .from(outputs)
+      .innerJoin(assets, eq(assets.id, outputs.assetId))
+      .where(eq(outputs.jobId, row.id))
+      .orderBy(outputs.createdAt);
+    const prompt = typeof row.input.prompt === "string" ? row.input.prompt : "";
+    return {
+      id: row.id,
+      workspaceId: row.workspaceId,
+      status: row.status,
+      prompt,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+      events: eventRows.map((event) => this.toJobEvent(event)),
+      outputs: outputRows.map((output) => this.toJobOutput(output.output, output.asset)),
+      ...(row.skillVersionId ? { skillVersionId: row.skillVersionId } : {}),
+      ...(row.providerProfileId ? { providerProfileId: row.providerProfileId } : {})
+    };
+  }
+
+  private toJobEvent(row: typeof jobEvents.$inferSelect): JobEvent {
+    return {
+      id: row.id,
+      type: row.type,
+      createdAt: row.createdAt.toISOString(),
+      ...(row.message ? { message: row.message } : {})
+    };
+  }
+
+  private toJobOutput(row: typeof outputs.$inferSelect, asset: typeof assets.$inferSelect): JobOutput {
+    return {
+      id: row.id,
+      assetId: asset.id,
+      label: row.label,
+      mimeType: asset.mimeType,
+      byteSize: asset.byteSize,
+      sha256: asset.sha256,
+      storagePath: asset.storagePath,
+      createdAt: row.createdAt.toISOString()
+    };
+  }
+
+  private assetPath(storagePath: string): string {
+    return join(this.assetRoot(), storagePath);
+  }
+
+  private assetRoot(): string {
+    return process.env.ASSET_STORAGE_DIR ?? ".data/assets";
+  }
+}

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -55,7 +55,9 @@ export class JobsService {
     if (provider.workspaceId !== parsed.workspaceId) {
       throw new ForbiddenException("Provider profile is not in this workspace");
     }
+    this.assertProviderCanGenerateImages(provider.capabilities);
     const skill = await this.getLatestValidSkillArchive(parsed.workspaceId, parsed.skillId);
+    this.assertSkillCanGenerateImages(skill.version.permissions);
     const skillMd = await readFile(this.assetPath(skill.asset.storagePath), "utf8");
     const fullPrompt = this.buildGenerationPrompt(skillMd, parsed.prompt);
 
@@ -130,6 +132,18 @@ export class JobsService {
     return row;
   }
 
+  private assertProviderCanGenerateImages(capabilities: string[]) {
+    if (!capabilities.includes("image-generate") || !capabilities.includes("tools")) {
+      throw new BadRequestException("Provider profile must include image-generate and tools capabilities");
+    }
+  }
+
+  private assertSkillCanGenerateImages(permissions: string[]) {
+    if (!permissions.includes("use-provider") || !permissions.includes("write-workspace-assets")) {
+      throw new BadRequestException("Skill must request use-provider and write-workspace-assets permissions");
+    }
+  }
+
   private buildGenerationPrompt(skillMd: string, userPrompt: string): string {
     return [
       "Use the following Agent Skill instructions for this image generation request.",
@@ -146,6 +160,9 @@ export class JobsService {
   private async writeOutputAsset(workspaceId: string, ownerId: string, bytes: Buffer) {
     const sha256 = createHash("sha256").update(bytes).digest("hex");
     const mimeType = this.sniffImageMimeType(bytes);
+    if (mimeType === "application/octet-stream") {
+      throw new ImageGenerationTransportError("Image generation result was not a supported image payload.", false);
+    }
     const extension = this.extensionForMimeType(mimeType);
     const storagePath = `output-images/${sha256}.${extension}`;
     const outputDir = join(this.assetRoot(), "output-images");

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -47,7 +47,7 @@ export class JobsService {
       skillId: input.skillId,
       prompt: input.prompt.trim()
     });
-    await this.workspaces.assertMember(parsed.workspaceId, userId);
+    await this.workspaces.assertCanWriteJobs(parsed.workspaceId, userId);
     const provider = await this.providerProfiles.getStored(parsed.providerProfileId);
     if (!provider) {
       throw new NotFoundException("Provider profile not found");

--- a/apps/api/src/workspaces/workspaces.service.ts
+++ b/apps/api/src/workspaces/workspaces.service.ts
@@ -8,6 +8,7 @@ import { AppDb } from "../db/types";
 import { Workspace, WorkspaceMember, WorkspaceMembership } from "./workspace.types";
 
 const membershipManagerRoles = new Set<WorkspaceMembership["role"]>(["owner", "admin"]);
+const jobWriterRoles = new Set<WorkspaceMembership["role"]>(["owner", "admin", "member"]);
 
 @Injectable()
 export class WorkspacesService {
@@ -57,6 +58,13 @@ export class WorkspacesService {
   async assertMember(workspaceId: string, userId: string): Promise<void> {
     if (!(await this.isMember(workspaceId, userId))) {
       throw new ForbiddenException("User is not a member of this workspace");
+    }
+  }
+
+  async assertCanWriteJobs(workspaceId: string, userId: string): Promise<void> {
+    const membership = await this.findMembership(workspaceId, userId);
+    if (!membership || !jobWriterRoles.has(membership.role)) {
+      throw new ForbiddenException("User cannot run workspace jobs");
     }
   }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,7 @@ import { useApolloClient, useMutation, useQuery } from "@apollo/client";
 import { Button } from "@base-ui/react/button";
 import { startAuthentication, startRegistration } from "@simplewebauthn/browser";
 import { Boxes, KeyRound, Settings, Upload, UsersRound } from "lucide-react";
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 import {
   ADD_WORKSPACE_MEMBER,
   CURRENT_USER_QUERY,
@@ -179,8 +179,12 @@ export function App() {
   const skillRows = skills.data?.skills ?? [];
   const memberRows = members.data?.workspaceMembers ?? [];
   const jobRows = generationJobs.data?.generationJobs ?? [];
-  const selectedProviderId = generationProviderId || providerRows[0]?.id || "";
-  const selectedSkillId = generationSkillId || skillRows[0]?.id || "";
+  const selectedProviderId = providerRows.some((profile) => profile.id === generationProviderId)
+    ? generationProviderId
+    : providerRows[0]?.id || "";
+  const selectedSkillId = skillRows.some((skill) => skill.id === generationSkillId)
+    ? generationSkillId
+    : skillRows[0]?.id || "";
   const latestJob = generationMutation.data?.runImageGenerationJob ?? jobRows[0];
   const currentUserName = currentUser?.displayName ?? "Loading user";
   const loginError = loginState.error?.message;
@@ -189,6 +193,11 @@ export function App() {
   const memberError = addMemberMutation.error?.message ?? updateMemberMutation.error?.message ?? removeMemberMutation.error?.message;
   const skillResult = skillMutation.data?.uploadSkill;
   const skillErrors = useMemo(() => skillResult?.version.validationErrors ?? [], [skillResult]);
+
+  useEffect(() => {
+    setGenerationProviderId("");
+    setGenerationSkillId("");
+  }, [activeWorkspace?.id]);
 
   async function handleLogin(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,10 +9,12 @@ import {
   CREATE_PROVIDER_PROFILE,
   FINISH_PASSKEY_AUTHENTICATION,
   FINISH_PASSKEY_REGISTRATION,
+  GENERATION_JOBS_QUERY,
   LOGIN_WITH_PASSWORD,
   LOGOUT,
   PROVIDER_PROFILES_QUERY,
   REMOVE_WORKSPACE_MEMBER,
+  RUN_IMAGE_GENERATION_JOB,
   SKILLS_QUERY,
   START_PASSKEY_AUTHENTICATION,
   START_PASSKEY_REGISTRATION,
@@ -43,6 +45,30 @@ interface Skill {
   name: string;
   slug: string;
   status: string;
+}
+
+interface GenerationJobOutput {
+  id: string;
+  label: string;
+  mimeType: string;
+  byteSize: number;
+  sha256: string;
+  storagePath: string;
+}
+
+interface GenerationJobEvent {
+  id: string;
+  type: string;
+  message?: string;
+  createdAt: string;
+}
+
+interface GenerationJob {
+  id: string;
+  status: string;
+  prompt: string;
+  events: GenerationJobEvent[];
+  outputs: GenerationJobOutput[];
 }
 
 type WorkspaceRole = "owner" | "admin" | "member" | "viewer";
@@ -79,6 +105,14 @@ interface WorkspaceMembersData {
   workspaceMembers: WorkspaceMember[];
 }
 
+interface GenerationJobsData {
+  generationJobs: GenerationJob[];
+}
+
+interface RunGenerationData {
+  runImageGenerationJob: GenerationJob;
+}
+
 interface LoggedInUser {
   userId: string;
   displayName: string;
@@ -97,6 +131,9 @@ export function App() {
   const [memberRole, setMemberRole] = useState<WorkspaceRole>("member");
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
   const [skillFile, setSkillFile] = useState<File | null>(null);
+  const [generationProviderId, setGenerationProviderId] = useState("");
+  const [generationSkillId, setGenerationSkillId] = useState("");
+  const [generationPrompt, setGenerationPrompt] = useState("Create a clean studio image using this skill.");
   const [loginMessage, setLoginMessage] = useState<string | null>(null);
   const [passkeyMessage, setPasskeyMessage] = useState<string | null>(null);
   const currentUserQuery = useQuery<DashboardData>(CURRENT_USER_QUERY, {
@@ -110,6 +147,7 @@ export function App() {
   const [finishPasskeyAuthenticationMutation] = useMutation(FINISH_PASSKEY_AUTHENTICATION);
   const [createProviderProfile, providerMutation] = useMutation(CREATE_PROVIDER_PROFILE);
   const [uploadSkill, skillMutation] = useMutation(UPLOAD_SKILL);
+  const [runGenerationJob, generationMutation] = useMutation<RunGenerationData>(RUN_IMAGE_GENERATION_JOB);
   const [addWorkspaceMember, addMemberMutation] = useMutation(ADD_WORKSPACE_MEMBER);
   const [updateWorkspaceMemberRole, updateMemberMutation] = useMutation(UPDATE_WORKSPACE_MEMBER_ROLE);
   const [removeWorkspaceMember, removeMemberMutation] = useMutation(REMOVE_WORKSPACE_MEMBER);
@@ -132,13 +170,22 @@ export function App() {
     variables: { workspaceId: activeWorkspace?.id ?? "" },
     skip: !activeWorkspace
   });
+  const generationJobs = useQuery<GenerationJobsData>(GENERATION_JOBS_QUERY, {
+    variables: { workspaceId: activeWorkspace?.id ?? "" },
+    skip: !activeWorkspace
+  });
 
   const providerRows = providers.data?.providerProfiles ?? [];
   const skillRows = skills.data?.skills ?? [];
   const memberRows = members.data?.workspaceMembers ?? [];
+  const jobRows = generationJobs.data?.generationJobs ?? [];
+  const selectedProviderId = generationProviderId || providerRows[0]?.id || "";
+  const selectedSkillId = generationSkillId || skillRows[0]?.id || "";
+  const latestJob = generationMutation.data?.runImageGenerationJob ?? jobRows[0];
   const currentUserName = currentUser?.displayName ?? "Loading user";
   const loginError = loginState.error?.message;
   const providerError = providerMutation.error?.message;
+  const generationError = generationMutation.error?.message;
   const memberError = addMemberMutation.error?.message ?? updateMemberMutation.error?.message ?? removeMemberMutation.error?.message;
   const skillResult = skillMutation.data?.uploadSkill;
   const skillErrors = useMemo(() => skillResult?.version.validationErrors ?? [], [skillResult]);
@@ -235,6 +282,22 @@ export function App() {
         }
       },
       refetchQueries: [{ query: SKILLS_QUERY, variables: { workspaceId: activeWorkspace.id } }]
+    });
+  }
+
+  async function handleGenerationSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!activeWorkspace || !selectedProviderId || !selectedSkillId) return;
+    await runGenerationJob({
+      variables: {
+        input: {
+          workspaceId: activeWorkspace.id,
+          providerProfileId: selectedProviderId,
+          skillId: selectedSkillId,
+          prompt: generationPrompt
+        }
+      },
+      refetchQueries: [{ query: GENERATION_JOBS_QUERY, variables: { workspaceId: activeWorkspace.id } }]
     });
   }
 
@@ -468,6 +531,66 @@ export function App() {
                 Upload Skill
               </Button>
             </form>
+          </section>
+
+          <section className="panel">
+            <div className="panel-header compact">
+              <div>
+                <h2>Generate Image</h2>
+                <p>Run the selected Agent Skill against a workspace provider.</p>
+              </div>
+            </div>
+            <form className="stacked-form" onSubmit={handleGenerationSubmit}>
+              <label>
+                Generation provider
+                <select
+                  value={selectedProviderId}
+                  onChange={(event) => setGenerationProviderId(event.target.value)}
+                >
+                  {providerRows.map((profile) => (
+                    <option key={profile.id} value={profile.id}>
+                      {profile.displayName}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Generation skill
+                <select value={selectedSkillId} onChange={(event) => setGenerationSkillId(event.target.value)}>
+                  {skillRows.map((skill) => (
+                    <option key={skill.id} value={skill.id}>
+                      {skill.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Image prompt
+                <textarea value={generationPrompt} onChange={(event) => setGenerationPrompt(event.target.value)} rows={4} />
+              </label>
+              {generationError ? <p className="error-text">{generationError}</p> : null}
+              <Button className="primary-button" type="submit" disabled={!selectedProviderId || !selectedSkillId || generationMutation.loading}>
+                {generationMutation.loading ? "Running" : "Run Generation"}
+              </Button>
+            </form>
+            {latestJob ? (
+              <div className="job-result" aria-label="Latest generation job">
+                <strong>Job {latestJob.status}</strong>
+                <span>{latestJob.prompt}</span>
+                {latestJob.outputs.map((output) => (
+                  <span key={output.id}>
+                    {output.label} - {output.mimeType} - {output.byteSize} bytes
+                  </span>
+                ))}
+                {latestJob.events
+                  .filter((event) => event.type === "failed" && event.message)
+                  .map((event) => (
+                    <span className="error-text" key={event.id}>
+                      {event.message}
+                    </span>
+                  ))}
+              </div>
+            ) : null}
           </section>
 
           <section className="panel">

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -65,6 +65,7 @@ interface GenerationJobEvent {
 
 interface GenerationJob {
   id: string;
+  workspaceId: string;
   status: string;
   prompt: string;
   events: GenerationJobEvent[];
@@ -185,7 +186,8 @@ export function App() {
   const selectedSkillId = skillRows.some((skill) => skill.id === generationSkillId)
     ? generationSkillId
     : skillRows[0]?.id || "";
-  const latestJob = generationMutation.data?.runImageGenerationJob ?? jobRows[0];
+  const mutationJob = generationMutation.data?.runImageGenerationJob;
+  const latestJob = mutationJob?.workspaceId === activeWorkspace?.id ? mutationJob : jobRows[0];
   const currentUserName = currentUser?.displayName ?? "Loading user";
   const loginError = loginState.error?.message;
   const providerError = providerMutation.error?.message;

--- a/apps/web/src/graphql.ts
+++ b/apps/web/src/graphql.ts
@@ -119,6 +119,34 @@ export const SKILLS_QUERY = gql`
   }
 `;
 
+export const GENERATION_JOBS_QUERY = gql`
+  query GenerationJobs($workspaceId: String!) {
+    generationJobs(workspaceId: $workspaceId) {
+      id
+      status
+      prompt
+      createdAt
+      updatedAt
+      events {
+        id
+        type
+        message
+        createdAt
+      }
+      outputs {
+        id
+        assetId
+        label
+        mimeType
+        byteSize
+        sha256
+        storagePath
+        createdAt
+      }
+    }
+  }
+`;
+
 export const CREATE_PROVIDER_PROFILE = gql`
   mutation CreateProviderProfile($input: ProviderProfileInput!) {
     createProviderProfile(input: $input) {
@@ -130,6 +158,30 @@ export const CREATE_PROVIDER_PROFILE = gql`
       defaultImageModel
       capabilities
       hasApiKey
+    }
+  }
+`;
+
+export const RUN_IMAGE_GENERATION_JOB = gql`
+  mutation RunImageGenerationJob($input: RunImageGenerationJobInput!) {
+    runImageGenerationJob(input: $input) {
+      id
+      status
+      prompt
+      events {
+        id
+        type
+        message
+        createdAt
+      }
+      outputs {
+        id
+        label
+        mimeType
+        byteSize
+        sha256
+        storagePath
+      }
     }
   }
 `;

--- a/apps/web/src/graphql.ts
+++ b/apps/web/src/graphql.ts
@@ -166,6 +166,7 @@ export const RUN_IMAGE_GENERATION_JOB = gql`
   mutation RunImageGenerationJob($input: RunImageGenerationJobInput!) {
     runImageGenerationJob(input: $input) {
       id
+      workspaceId
       status
       prompt
       events {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -266,7 +266,8 @@ button {
 
 .skill-list,
 .member-list,
-.metric-list {
+.metric-list,
+.job-result {
   display: grid;
   gap: 10px;
 }
@@ -301,10 +302,21 @@ button {
 
 .skill-item,
 .member-item,
-.metric-list > div {
+.metric-list > div,
+.job-result {
   border: 1px solid #e2e9e5;
   border-radius: 8px;
   padding: 12px;
+}
+
+.job-result {
+  margin-top: 14px;
+  font-size: 0.9rem;
+}
+
+.job-result span {
+  color: #5c6a64;
+  overflow-wrap: anywhere;
 }
 
 .member-item {

--- a/packages/shared/src/jobs.ts
+++ b/packages/shared/src/jobs.ts
@@ -6,3 +6,10 @@ export type JobStatus = z.infer<typeof jobStatusSchema>;
 export const jobEventTypeSchema = z.enum(["created", "queued", "started", "progress", "completed", "failed", "canceled"]);
 export type JobEventType = z.infer<typeof jobEventTypeSchema>;
 
+export const imageGenerationJobInputSchema = z.object({
+  workspaceId: z.string().uuid(),
+  providerProfileId: z.string().uuid(),
+  skillId: z.string().uuid(),
+  prompt: z.string().min(1).max(4000)
+});
+export type ImageGenerationJobInput = z.infer<typeof imageGenerationJobInputSchema>;

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -389,18 +389,20 @@ Always produce a sharp product image.
 
       await page.getByLabel("Generation provider").selectOption({ label: "Generation Mock Provider" });
       await page.getByLabel("Generation skill").selectOption({ label: "mock-generation-skill" });
-      await page.getByLabel("Image prompt").fill("Create a chrome object on a neutral background.");
+      const prompt = `Create a chrome object on a neutral background ${Date.now()}.`;
+      await page.getByLabel("Image prompt").fill(prompt);
       await page.getByRole("button", { name: "Run Generation" }).click();
 
-      await expect(page.getByText("Job succeeded")).toBeVisible();
-      await expect(page.getByText("generated-image - image/png")).toBeVisible();
-      expect(mock.requests).toHaveLength(1);
+      await expect.poll(() => mock.requests.length).toBe(1);
+      await expect(page.getByLabel("Latest generation job")).toContainText("Job succeeded");
+      await expect(page.getByLabel("Latest generation job")).toContainText(prompt);
+      await expect(page.getByLabel("Latest generation job")).toContainText("generated-image - image/png");
       expect(mock.requests[0]?.headers.authorization).toBe("Bearer mock-secret-key");
       expect(mock.requests[0]?.body.model).toBe("gpt-mock-responses");
       expect(mock.requests[0]?.body.stream).toBe(true);
       expect(mock.requests[0]?.body.input).toContain("mock-generation-skill");
       expect(mock.requests[0]?.body.input).toContain("Always produce a sharp product image.");
-      expect(mock.requests[0]?.body.input).toContain("Create a chrome object on a neutral background.");
+      expect(mock.requests[0]?.body.input).toContain(prompt);
       expect(mock.requests[0]?.body.tools).toEqual([
         { type: "image_generation", model: "gpt-mock-responses", action: "generate" }
       ]);

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -144,6 +144,46 @@ test.describe("foundation workspace flows", () => {
     await expect(page.locator(".member-item").filter({ hasText: accounts[0].displayName })).toHaveCount(0);
   });
 
+  test("keeps generation selections scoped to the active workspace", async ({ page }) => {
+    await resetBrowserState(page);
+    await login(page);
+    const firstProviderId = await createProviderProfile(page, {
+      name: "First Workspace Provider",
+      baseUrl: "http://127.0.0.1:1/v1",
+      model: "first-workspace-model",
+      apiKey: "mock-secret-key"
+    });
+    await uploadSkillFromUi(page, "first-workspace-skill.md", `---
+name: first-workspace-skill
+description: First workspace skill.
+---
+
+# First Workspace Skill
+`);
+    await page.getByLabel("Generation provider").selectOption({ label: "First Workspace Provider" });
+    await page.getByLabel("Generation skill").selectOption({ label: "first-workspace-skill" });
+
+    const workspaceName = "Second Workspace";
+    await page.evaluate(async (name) => {
+      await fetch("http://localhost:4000/graphql", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          query: "mutation CreateWorkspace($name: String!) { createWorkspace(name: $name) { id } }",
+          variables: { name }
+        })
+      });
+    }, workspaceName);
+    await page.reload();
+    await page.getByLabel("Active workspace").selectOption({ label: workspaceName });
+    await expect(page.getByRole("heading", { name: workspaceName })).toBeVisible();
+    await expect(page.getByLabel("Generation provider")).not.toHaveValue(firstProviderId);
+    await expect(page.getByLabel("Generation provider")).toHaveValue("");
+    await expect(page.getByLabel("Generation skill")).toHaveValue("");
+    await expect(page.getByRole("button", { name: "Run Generation" })).toBeDisabled();
+  });
+
   test("rejects invalid password login", async ({ page }) => {
     await page.goto("/");
     await page.getByLabel("Email").fill(accounts[0].email);
@@ -536,17 +576,10 @@ async function uploadSkillViaGraphql(
 async function createProviderProfile(
   page: Page,
   input: { name: string; baseUrl: string; model: string; apiKey: string; capabilities?: string[] }
-): Promise<void> {
-  await page.evaluate(async (providerInput) => {
-    const workspaceResponse = await fetch("http://localhost:4000/graphql", {
-      method: "POST",
-      credentials: "include",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ query: "{ workspacesForCurrentUser { id } }" })
-    });
-    const workspaceJson = await workspaceResponse.json();
-    const workspaceId = workspaceJson.data.workspacesForCurrentUser[0].id as string;
-    await fetch("http://localhost:4000/graphql", {
+): Promise<string> {
+  const workspaceId = await activeWorkspaceId(page);
+  const providerId = await page.evaluate(async ({ providerInput, workspaceId }) => {
+    const response = await fetch("http://localhost:4000/graphql", {
       method: "POST",
       credentials: "include",
       headers: { "content-type": "application/json" },
@@ -568,9 +601,41 @@ async function createProviderProfile(
         }
       })
     });
-  }, input);
+    const json = await response.json();
+    if (json.errors?.length) {
+      throw new Error(json.errors[0].message);
+    }
+    return json.data.createProviderProfile.id as string;
+  }, { providerInput: input, workspaceId });
   await page.reload();
-  await expect(page.locator(".table-row").filter({ hasText: input.name })).toBeVisible();
+  if ((await page.getByLabel("Active workspace").count()) > 0) {
+    await page.getByLabel("Active workspace").selectOption(workspaceId);
+  }
+  return providerId;
+}
+
+async function activeWorkspaceId(page: Page): Promise<string> {
+  if ((await page.getByLabel("Active workspace").count()) > 0) {
+    return page.getByLabel("Active workspace").inputValue();
+  }
+  return currentWorkspaceId(page);
+}
+
+async function uploadSkillFromUi(page: Page, fileName: string, content: string): Promise<void> {
+  const filePath = await writeSkillFile(fileName, content);
+  const skillName = content.match(/^name:\s*(.+)$/m)?.[1]?.trim();
+  await page.getByLabel("SKILL.md file").setInputFiles(filePath);
+  await page.getByRole("button", { name: "Upload Skill" }).click();
+  if (skillName) {
+    await expect(page.getByText(`Indexed ${skillName}`)).toBeVisible();
+  }
+}
+
+async function selectValueForLabel(page: Page, label: string, optionLabel: string): Promise<string> {
+  return page.getByLabel(label).evaluate((select, text) => {
+    const option = [...(select as HTMLSelectElement).options].find((item) => item.textContent === text);
+    return option?.value ?? "";
+  }, optionLabel);
 }
 
 async function startResponsesMock(options: { outputBytes?: Buffer; status?: number; body?: string }): Promise<{

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -184,6 +184,57 @@ description: First workspace skill.
     await expect(page.getByRole("button", { name: "Run Generation" })).toBeDisabled();
   });
 
+  test("does not show the last generated job after switching workspaces", async ({ page }) => {
+    const outputBytes = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+      "base64"
+    );
+    const mock = await startResponsesMock({ outputBytes });
+    try {
+      await resetBrowserState(page);
+      await login(page);
+      await createProviderProfile(page, {
+        name: "Scoped Job Provider",
+        baseUrl: mock.baseUrl,
+        model: "scoped-job-model",
+        apiKey: "mock-secret-key"
+      });
+      await uploadSkillFromUi(page, "scoped-job-skill.md", `---
+name: scoped-job-skill
+description: Scoped job skill.
+---
+
+# Scoped Job Skill
+`);
+      await page.getByLabel("Generation provider").selectOption({ label: "Scoped Job Provider" });
+      await page.getByLabel("Generation skill").selectOption({ label: "scoped-job-skill" });
+      await page.getByLabel("Image prompt").fill("Workspace A generated prompt.");
+      await page.getByRole("button", { name: "Run Generation" }).click();
+      await expect(page.getByText("Job succeeded")).toBeVisible();
+      await expect(page.getByLabel("Latest generation job")).toContainText("Workspace A generated prompt.");
+
+      const workspaceName = "No Jobs Workspace";
+      await page.evaluate(async (name) => {
+        await fetch("http://localhost:4000/graphql", {
+          method: "POST",
+          credentials: "include",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            query: "mutation CreateWorkspace($name: String!) { createWorkspace(name: $name) { id } }",
+            variables: { name }
+          })
+        });
+      }, workspaceName);
+      await page.reload();
+      await page.getByLabel("Active workspace").selectOption({ label: workspaceName });
+
+      await expect(page.getByRole("heading", { name: workspaceName })).toBeVisible();
+      await expect(page.getByLabel("Latest generation job")).toHaveCount(0);
+    } finally {
+      await mock.close();
+    }
+  });
+
   test("rejects invalid password login", async ({ page }) => {
     await page.goto("/");
     await page.getByLabel("Email").fill(accounts[0].email);
@@ -435,6 +486,51 @@ description: Valid skill without provider permissions.
       await page.getByRole("button", { name: "Run Generation" }).click();
 
       await expect(page.getByText("Skill must request use-provider and write-workspace-assets permissions")).toBeVisible();
+      expect(mock.requests).toHaveLength(0);
+    } finally {
+      await mock.close();
+    }
+  });
+
+  test("rejects generation for workspace viewers before provider key use", async ({ page }) => {
+    const mock = await startResponsesMock({
+      outputBytes: Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+        "base64"
+      )
+    });
+    try {
+      await resetBrowserState(page);
+      await login(page, accounts[1]);
+      await signOut(page);
+      await login(page, accounts[0]);
+      await createProviderProfile(page, {
+        name: "Viewer Block Provider",
+        baseUrl: mock.baseUrl,
+        model: "viewer-block-model",
+        apiKey: "mock-secret-key"
+      });
+      await uploadSkillFromUi(page, "viewer-block-skill.md", `---
+name: viewer-block-skill
+description: Viewer block skill.
+---
+
+# Viewer Block Skill
+`);
+      await page.getByLabel("Member email").fill(accounts[1].email);
+      await page.getByLabel("New member role").selectOption("viewer");
+      await page.getByRole("button", { name: "Add Member" }).click();
+      const ownerWorkspaceId = await currentWorkspaceId(page);
+
+      await signOut(page);
+      await login(page, accounts[1]);
+      await page.getByLabel("Active workspace").selectOption(ownerWorkspaceId);
+      await page.getByLabel("Generation provider").selectOption({ label: "Viewer Block Provider" });
+      await page.getByLabel("Generation skill").selectOption({ label: "viewer-block-skill" });
+      await page.getByLabel("Image prompt").fill("Viewer should not run this.");
+      await page.getByRole("button", { name: "Run Generation" }).click();
+
+      await expect(page.getByText("User cannot run workspace jobs")).toBeVisible();
       expect(mock.requests).toHaveLength(0);
     } finally {
       await mock.close();

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -1,6 +1,8 @@
 import { expect, Page, test } from "@playwright/test";
 import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { createServer, Server } from "node:http";
+import { AddressInfo } from "node:net";
 import { join } from "node:path";
 
 const accounts = [
@@ -159,7 +161,7 @@ test.describe("foundation workspace flows", () => {
     await page.getByLabel("API key").fill("super-secret-e2e-key");
     await page.getByRole("button", { name: "Save Provider" }).click();
 
-    await expect(page.getByText("Workspace Image Provider")).toBeVisible();
+    await expect(page.locator(".table-row").filter({ hasText: "Workspace Image Provider" })).toBeVisible();
     await expect(page.getByText("https://models.example.test/v1")).toBeVisible();
     await expect(page.getByText("gpt-image-workspace")).toBeVisible();
     await expect(page.getByText("super-secret-e2e-key")).toHaveCount(0);
@@ -266,6 +268,91 @@ description: Hash mismatch check.
     });
     expect(invalidBase64.errors?.[0]?.message).toContain("canonical base64");
   });
+
+  test("runs an uploaded Agent Skill through a gen-gallery compatible responses stream", async ({ page }) => {
+    const outputBytes = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+      "base64"
+    );
+    const mock = await startResponsesMock({ outputBytes });
+    try {
+      await login(page);
+      await createProviderProfile(page, {
+        name: "Generation Mock Provider",
+        baseUrl: mock.baseUrl,
+        model: "gpt-mock-responses",
+        apiKey: "mock-secret-key"
+      });
+      const skillPath = await writeSkillFile("mock-generation-skill.md", `---
+name: mock-generation-skill
+description: Drives the mock generation request.
+---
+
+# Mock Generation Skill
+
+Always produce a sharp product image.
+`);
+      await page.getByLabel("SKILL.md file").setInputFiles(skillPath);
+      await page.getByRole("button", { name: "Upload Skill" }).click();
+      await expect(page.getByText("Indexed mock-generation-skill")).toBeVisible();
+
+      await page.getByLabel("Generation provider").selectOption({ label: "Generation Mock Provider" });
+      await page.getByLabel("Generation skill").selectOption({ label: "mock-generation-skill" });
+      await page.getByLabel("Image prompt").fill("Create a chrome object on a neutral background.");
+      await page.getByRole("button", { name: "Run Generation" }).click();
+
+      await expect(page.getByText("Job succeeded")).toBeVisible();
+      await expect(page.getByText("generated-image - image/png")).toBeVisible();
+      expect(mock.requests).toHaveLength(1);
+      expect(mock.requests[0]?.headers.authorization).toBe("Bearer mock-secret-key");
+      expect(mock.requests[0]?.body.model).toBe("gpt-mock-responses");
+      expect(mock.requests[0]?.body.stream).toBe(true);
+      expect(mock.requests[0]?.body.input).toContain("mock-generation-skill");
+      expect(mock.requests[0]?.body.input).toContain("Always produce a sharp product image.");
+      expect(mock.requests[0]?.body.input).toContain("Create a chrome object on a neutral background.");
+      expect(mock.requests[0]?.body.tools).toEqual([
+        { type: "image_generation", model: "gpt-mock-responses", action: "generate" }
+      ]);
+      const sha256 = createHash("sha256").update(outputBytes).digest("hex");
+      const storedBytes = await readFile(join(process.cwd(), "apps/api/.data/assets/output-images", `${sha256}.png`));
+      expect(storedBytes.equals(outputBytes)).toBe(true);
+    } finally {
+      await mock.close();
+    }
+  });
+
+  test("shows a failed generation job when the responses upstream fails", async ({ page }) => {
+    const mock = await startResponsesMock({ status: 500, body: "mock upstream failure" });
+    try {
+      await login(page);
+      await createProviderProfile(page, {
+        name: "Failing Mock Provider",
+        baseUrl: mock.baseUrl,
+        model: "gpt-mock-failure",
+        apiKey: "mock-secret-key"
+      });
+      const skillPath = await writeSkillFile("mock-failure-skill.md", `---
+name: mock-failure-skill
+description: Drives the mock failed generation request.
+---
+
+# Mock Failure Skill
+`);
+      await page.getByLabel("SKILL.md file").setInputFiles(skillPath);
+      await page.getByRole("button", { name: "Upload Skill" }).click();
+      await expect(page.getByText("Indexed mock-failure-skill")).toBeVisible();
+
+      await page.getByLabel("Generation provider").selectOption({ label: "Failing Mock Provider" });
+      await page.getByLabel("Generation skill").selectOption({ label: "mock-failure-skill" });
+      await page.getByLabel("Image prompt").fill("This request should fail.");
+      await page.getByRole("button", { name: "Run Generation" }).click();
+
+      await expect(page.getByText("Job failed")).toBeVisible();
+      await expect(page.getByText(/Responses request failed with HTTP 500: mock upstream failure/)).toBeVisible();
+    } finally {
+      await mock.close();
+    }
+  });
 });
 
 async function currentWorkspaceId(page: Page): Promise<string> {
@@ -330,4 +417,73 @@ async function uploadSkillViaGraphql(
     });
     return response.json();
   }, input);
+}
+
+async function createProviderProfile(
+  page: Page,
+  input: { name: string; baseUrl: string; model: string; apiKey: string }
+): Promise<void> {
+  await page.getByLabel("Provider name").fill(input.name);
+  await page.getByLabel("Base URL").fill(input.baseUrl);
+  await page.getByLabel("Default model").fill(input.model);
+  await page.getByLabel("API key").fill(input.apiKey);
+  await page.getByRole("button", { name: "Save Provider" }).click();
+  await expect(page.locator(".table-row").filter({ hasText: input.name })).toBeVisible();
+}
+
+async function startResponsesMock(options: { outputBytes?: Buffer; status?: number; body?: string }): Promise<{
+  baseUrl: string;
+  requests: Array<{ headers: Record<string, string | undefined>; body: Record<string, unknown> }>;
+  close: () => Promise<void>;
+}> {
+  const requests: Array<{ headers: Record<string, string | undefined>; body: Record<string, unknown> }> = [];
+  const server = createServer(async (request, response) => {
+    if (request.method !== "POST" || !request.url?.endsWith("/responses")) {
+      response.writeHead(404).end("not found");
+      return;
+    }
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    requests.push({
+      headers: {
+        authorization: request.headers.authorization,
+        accept: request.headers.accept,
+        contentType: request.headers["content-type"]
+      },
+      body: JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>
+    });
+    if (options.status && options.status >= 400) {
+      response.writeHead(options.status, { "content-type": "text/plain" }).end(options.body ?? "upstream failure");
+      return;
+    }
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    response.write(
+      `data: ${JSON.stringify({
+        type: "response.output_item.done",
+        item: {
+          type: "image_generation_call",
+          result: (options.outputBytes ?? Buffer.from("mock image")).toString("base64")
+        }
+      })}\n\n`
+    );
+    response.end("data: [DONE]\n\n");
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    requests,
+    close: () => closeServer(server)
+  };
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
 }

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -353,6 +353,120 @@ description: Drives the mock failed generation request.
       await mock.close();
     }
   });
+
+  test("rejects generation when skill permissions do not allow provider and asset writes", async ({ page }) => {
+    const outputBytes = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+      "base64"
+    );
+    const mock = await startResponsesMock({ outputBytes });
+    try {
+      await login(page);
+      await createProviderProfile(page, {
+        name: "Permission Mock Provider",
+        baseUrl: mock.baseUrl,
+        model: "gpt-mock-permission",
+        apiKey: "mock-secret-key"
+      });
+      const workspaceId = await currentWorkspaceId(page);
+      const skillPath = await writeSkillFile("no-permissions-skill.md", `---
+name: no-permissions-skill
+description: Valid skill without provider permissions.
+---
+
+# No Permissions Skill
+`);
+      const bytes = await readFile(skillPath);
+      const upload = await uploadSkillViaGraphql(page, {
+        workspaceId,
+        archiveSha256: createHash("sha256").update(bytes).digest("hex"),
+        fileName: "no-permissions-skill.md",
+        mimeType: "text/markdown",
+        byteSize: bytes.length,
+        contentBase64: bytes.toString("base64")
+      });
+      expect(upload.data?.uploadSkill.skill.id).toBeTruthy();
+      await page.reload();
+      await expect(page.getByLabel("Generation skill").locator("option", { hasText: "no-permissions-skill" })).toHaveCount(1);
+
+      await page.getByLabel("Generation provider").selectOption({ label: "Permission Mock Provider" });
+      await page.getByLabel("Generation skill").selectOption({ label: "no-permissions-skill" });
+      await page.getByLabel("Image prompt").fill("This request should be blocked before upstream.");
+      await page.getByRole("button", { name: "Run Generation" }).click();
+
+      await expect(page.getByText("Skill must request use-provider and write-workspace-assets permissions")).toBeVisible();
+      expect(mock.requests).toHaveLength(0);
+    } finally {
+      await mock.close();
+    }
+  });
+
+  test("rejects generation before upstream when provider lacks image tool capabilities", async ({ page }) => {
+    const mock = await startResponsesMock({ outputBytes: Buffer.from("not reached") });
+    try {
+      await login(page);
+      await createProviderProfile(page, {
+        name: "No Capability Provider",
+        baseUrl: mock.baseUrl,
+        model: "gpt-mock-no-capability",
+        apiKey: "mock-secret-key",
+        capabilities: []
+      });
+      const skillPath = await writeSkillFile("capability-skill.md", `---
+name: capability-skill
+description: Valid skill for capability rejection.
+---
+
+# Capability Skill
+`);
+      await page.getByLabel("SKILL.md file").setInputFiles(skillPath);
+      await page.getByRole("button", { name: "Upload Skill" }).click();
+      await expect(page.getByText("Indexed capability-skill")).toBeVisible();
+
+      await page.getByLabel("Generation provider").selectOption({ label: "No Capability Provider" });
+      await page.getByLabel("Generation skill").selectOption({ label: "capability-skill" });
+      await page.getByLabel("Image prompt").fill("This request should be blocked by provider capabilities.");
+      await page.getByRole("button", { name: "Run Generation" }).click();
+
+      await expect(page.getByText("Provider profile must include image-generate and tools capabilities")).toBeVisible();
+      expect(mock.requests).toHaveLength(0);
+    } finally {
+      await mock.close();
+    }
+  });
+
+  test("marks generation failed when upstream returns a non-image payload", async ({ page }) => {
+    const mock = await startResponsesMock({ outputBytes: Buffer.from("plain text is not an image") });
+    try {
+      await login(page);
+      await createProviderProfile(page, {
+        name: "Non Image Mock Provider",
+        baseUrl: mock.baseUrl,
+        model: "gpt-mock-non-image",
+        apiKey: "mock-secret-key"
+      });
+      const skillPath = await writeSkillFile("non-image-skill.md", `---
+name: non-image-skill
+description: Valid skill for non-image rejection.
+---
+
+# Non Image Skill
+`);
+      await page.getByLabel("SKILL.md file").setInputFiles(skillPath);
+      await page.getByRole("button", { name: "Upload Skill" }).click();
+      await expect(page.getByText("Indexed non-image-skill")).toBeVisible();
+
+      await page.getByLabel("Generation provider").selectOption({ label: "Non Image Mock Provider" });
+      await page.getByLabel("Generation skill").selectOption({ label: "non-image-skill" });
+      await page.getByLabel("Image prompt").fill("This request should fail after upstream.");
+      await page.getByRole("button", { name: "Run Generation" }).click();
+
+      await expect(page.getByText("Job failed")).toBeVisible();
+      await expect(page.getByText("Image generation result was not a supported image payload.")).toBeVisible();
+    } finally {
+      await mock.close();
+    }
+  });
 });
 
 async function currentWorkspaceId(page: Page): Promise<string> {
@@ -421,13 +535,41 @@ async function uploadSkillViaGraphql(
 
 async function createProviderProfile(
   page: Page,
-  input: { name: string; baseUrl: string; model: string; apiKey: string }
+  input: { name: string; baseUrl: string; model: string; apiKey: string; capabilities?: string[] }
 ): Promise<void> {
-  await page.getByLabel("Provider name").fill(input.name);
-  await page.getByLabel("Base URL").fill(input.baseUrl);
-  await page.getByLabel("Default model").fill(input.model);
-  await page.getByLabel("API key").fill(input.apiKey);
-  await page.getByRole("button", { name: "Save Provider" }).click();
+  await page.evaluate(async (providerInput) => {
+    const workspaceResponse = await fetch("http://localhost:4000/graphql", {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "{ workspacesForCurrentUser { id } }" })
+    });
+    const workspaceJson = await workspaceResponse.json();
+    const workspaceId = workspaceJson.data.workspacesForCurrentUser[0].id as string;
+    await fetch("http://localhost:4000/graphql", {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        query: `mutation CreateProviderProfile($input: ProviderProfileInput!) {
+          createProviderProfile(input: $input) { id }
+        }`,
+        variables: {
+          input: {
+            workspaceId,
+            displayName: providerInput.name,
+            providerType: "OPENAI_COMPATIBLE",
+            baseUrl: providerInput.baseUrl,
+            defaultModel: providerInput.model,
+            defaultImageModel: providerInput.model,
+            capabilities: providerInput.capabilities ?? ["image-generate", "tools"],
+            apiKey: providerInput.apiKey
+          }
+        }
+      })
+    });
+  }, input);
+  await page.reload();
   await expect(page.locator(".table-row").filter({ hasText: input.name })).toBeVisible();
 }
 


### PR DESCRIPTION
## Summary

- Closes #11 by adding a job GraphQL API that runs selected uploaded Agent Skills against workspace provider profiles.
- Adds a gen-gallery-compatible Responses SSE image client that posts to /responses and parses image_generation_call.result output bytes without using AI SDK image transport.
- Persists job events, output image assets, and output rows under local asset storage with skill permission, provider capability, image payload, workspace selection, and jobs:write validation.
- Adds frontend generation controls plus Playwright e2e mock upstream coverage for success, failed jobs, permission denial, capability denial, non-image payload rejection, viewer denial, workspace switching, and current-request SSE assertions.

## Linked Issue

Closes #11

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gen-image-studio/issues/11#issuecomment-4349639846

## Validation

- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:e2e

