### PR TITLE
Show collaborative workspace generation job history

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -173,7 +173,8 @@ export function App() {
   });
   const generationJobs = useQuery<GenerationJobsData>(GENERATION_JOBS_QUERY, {
     variables: { workspaceId: activeWorkspace?.id ?? "" },
-    skip: !activeWorkspace
+    skip: !activeWorkspace,
+    pollInterval: 3000
   });
 
   const providerRows = providers.data?.providerProfiles ?? [];
@@ -186,8 +187,6 @@ export function App() {
   const selectedSkillId = skillRows.some((skill) => skill.id === generationSkillId)
     ? generationSkillId
     : skillRows[0]?.id || "";
-  const mutationJob = generationMutation.data?.runImageGenerationJob;
-  const latestJob = mutationJob?.workspaceId === activeWorkspace?.id ? mutationJob : jobRows[0];
   const currentUserName = currentUser?.displayName ?? "Loading user";
   const loginError = loginState.error?.message;
   const providerError = providerMutation.error?.message;
@@ -584,24 +583,27 @@ export function App() {
                 {generationMutation.loading ? "Running" : "Run Generation"}
               </Button>
             </form>
-            {latestJob ? (
-              <div className="job-result" aria-label="Latest generation job">
-                <strong>Job {latestJob.status}</strong>
-                <span>{latestJob.prompt}</span>
-                {latestJob.outputs.map((output) => (
-                  <span key={output.id}>
-                    {output.label} - {output.mimeType} - {output.byteSize} bytes
-                  </span>
-                ))}
-                {latestJob.events
-                  .filter((event) => event.type === "failed" && event.message)
-                  .map((event) => (
-                    <span className="error-text" key={event.id}>
-                      {event.message}
-                    </span>
-                  ))}
-              </div>
-            ) : null}
+            <div className="job-history" aria-label="Generation history">
+              {jobRows.length === 0 ? (
+                <div className="empty-block">No generation jobs in this workspace.</div>
+              ) : (
+                jobRows.map((job) => {
+                  const latestEvent = job.events.at(-1);
+                  return (
+                    <article className="job-result" key={job.id}>
+                      <strong>Job {job.status}</strong>
+                      <span>{job.prompt}</span>
+                      {latestEvent?.message ? <span>{latestEvent.message}</span> : null}
+                      {job.outputs.map((output) => (
+                        <span key={output.id}>
+                          {output.label} - {output.mimeType} - {output.byteSize} bytes
+                        </span>
+                      ))}
+                    </article>
+                  );
+                })
+              )}
+            </div>
           </section>
 
           <section className="panel">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -267,6 +267,7 @@ button {
 .skill-list,
 .member-list,
 .metric-list,
+.job-history,
 .job-result {
   display: grid;
   gap: 10px;

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -519,6 +519,13 @@ description: Viewer block skill.
 
 # Viewer Block Skill
 `);
+      const historyPrompt = `Viewer readable history prompt ${Date.now()}.`;
+      await page.getByLabel("Generation provider").selectOption({ label: "Viewer Block Provider" });
+      await page.getByLabel("Generation skill").selectOption({ label: "viewer-block-skill" });
+      await page.getByLabel("Image prompt").fill(historyPrompt);
+      await page.getByRole("button", { name: "Run Generation" }).click();
+      await expect.poll(() => mock.requests.length).toBe(1);
+      await expect(page.getByLabel("Generation history")).toContainText(historyPrompt);
       await page.getByLabel("Member email").fill(accounts[1].email);
       await page.getByLabel("New member role").selectOption("viewer");
       await page.getByRole("button", { name: "Add Member" }).click();
@@ -527,13 +534,15 @@ description: Viewer block skill.
       await signOut(page);
       await login(page, accounts[1]);
       await page.getByLabel("Active workspace").selectOption(ownerWorkspaceId);
+      await expect(page.getByLabel("Generation history")).toContainText(historyPrompt);
+      await expect(page.getByLabel("Generation history")).toContainText("generated-image - image/png");
       await page.getByLabel("Generation provider").selectOption({ label: "Viewer Block Provider" });
       await page.getByLabel("Generation skill").selectOption({ label: "viewer-block-skill" });
       await page.getByLabel("Image prompt").fill("Viewer should not run this.");
       await page.getByRole("button", { name: "Run Generation" }).click();
 
       await expect(page.getByText("User cannot run workspace jobs")).toBeVisible();
-      expect(mock.requests).toHaveLength(0);
+      expect(mock.requests).toHaveLength(1);
     } finally {
       await mock.close();
     }

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -211,7 +211,7 @@ description: Scoped job skill.
       await page.getByLabel("Image prompt").fill("Workspace A generated prompt.");
       await page.getByRole("button", { name: "Run Generation" }).click();
       await expect(page.getByText("Job succeeded")).toBeVisible();
-      await expect(page.getByLabel("Latest generation job")).toContainText("Workspace A generated prompt.");
+      await expect(page.getByLabel("Generation history")).toContainText("Workspace A generated prompt.");
 
       const workspaceName = "No Jobs Workspace";
       await page.evaluate(async (name) => {
@@ -229,7 +229,7 @@ description: Scoped job skill.
       await page.getByLabel("Active workspace").selectOption({ label: workspaceName });
 
       await expect(page.getByRole("heading", { name: workspaceName })).toBeVisible();
-      await expect(page.getByLabel("Latest generation job")).toHaveCount(0);
+      await expect(page.getByLabel("Generation history")).not.toContainText("Workspace A generated prompt.");
     } finally {
       await mock.close();
     }
@@ -394,9 +394,9 @@ Always produce a sharp product image.
       await page.getByRole("button", { name: "Run Generation" }).click();
 
       await expect.poll(() => mock.requests.length).toBe(1);
-      await expect(page.getByLabel("Latest generation job")).toContainText("Job succeeded");
-      await expect(page.getByLabel("Latest generation job")).toContainText(prompt);
-      await expect(page.getByLabel("Latest generation job")).toContainText("generated-image - image/png");
+      await expect(page.getByLabel("Generation history")).toContainText("Job succeeded");
+      await expect(page.getByLabel("Generation history")).toContainText(prompt);
+      await expect(page.getByLabel("Generation history")).toContainText("generated-image - image/png");
       expect(mock.requests[0]?.headers.authorization).toBe("Bearer mock-secret-key");
       expect(mock.requests[0]?.body.model).toBe("gpt-mock-responses");
       expect(mock.requests[0]?.body.stream).toBe(true);
@@ -534,6 +534,55 @@ description: Viewer block skill.
 
       await expect(page.getByText("User cannot run workspace jobs")).toBeVisible();
       expect(mock.requests).toHaveLength(0);
+    } finally {
+      await mock.close();
+    }
+  });
+
+  test("shows generated job history to another workspace collaborator", async ({ page }) => {
+    const outputBytes = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+      "base64"
+    );
+    const mock = await startResponsesMock({ outputBytes });
+    try {
+      await resetBrowserState(page);
+      await login(page, accounts[2]);
+      await signOut(page);
+      await login(page, accounts[0]);
+      await createProviderProfile(page, {
+        name: "Shared History Provider",
+        baseUrl: mock.baseUrl,
+        model: "shared-history-model",
+        apiKey: "mock-secret-key"
+      });
+      await uploadSkillFromUi(page, "shared-history-skill.md", `---
+name: shared-history-skill
+description: Shared history skill.
+---
+
+# Shared History Skill
+`);
+      await page.getByLabel("Member email").fill(accounts[2].email);
+      await page.getByLabel("New member role").selectOption("member");
+      await page.getByRole("button", { name: "Add Member" }).click();
+      const ownerWorkspaceId = await currentWorkspaceId(page);
+      const prompt = `Collaborative history prompt ${Date.now()}.`;
+
+      await page.getByLabel("Generation provider").selectOption({ label: "Shared History Provider" });
+      await page.getByLabel("Generation skill").selectOption({ label: "shared-history-skill" });
+      await page.getByLabel("Image prompt").fill(prompt);
+      await page.getByRole("button", { name: "Run Generation" }).click();
+      await expect.poll(() => mock.requests.length).toBe(1);
+      await expect(page.getByLabel("Generation history")).toContainText(prompt);
+
+      await signOut(page);
+      await login(page, accounts[2]);
+      await page.getByLabel("Active workspace").selectOption(ownerWorkspaceId);
+
+      await expect(page.getByLabel("Generation history")).toContainText(prompt);
+      await expect(page.getByLabel("Generation history")).toContainText("Job succeeded");
+      await expect(page.getByLabel("Generation history")).toContainText("generated-image - image/png");
     } finally {
       await mock.close();
     }


### PR DESCRIPTION
## Summary

- Closes #13 by replacing the single latest generation result with workspace-scoped generation history from the persisted jobs query.
- Shows job status, prompt, latest event message, and output metadata, with polling and refetch after generation.
- Keeps generation controls scoped to active provider/skill selections and preserves server-side jobs:write enforcement.
- Expands Playwright e2e to cover cross-account collaborative history visibility plus viewer read/blocked-write behavior.

## Linked Issue

Closes #13

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gen-image-studio/issues/13#issuecomment-4349940587

## Validation

- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:e2e

