### PR TITLE
Preview generated output images

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,6 +3,7 @@ import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { GraphQLModule } from "@nestjs/graphql";
 import { AiModule } from "./ai/ai.module";
+import { AssetsModule } from "./assets/assets.module";
 import { AuthModule } from "./auth/auth.module";
 import { DbModule } from "./db/db.module";
 import { JobsModule } from "./jobs/jobs.module";
@@ -25,6 +26,7 @@ import { WorkspacesModule } from "./workspaces/workspaces.module";
     AuthModule,
     ProviderProfilesModule,
     AiModule,
+    AssetsModule,
     SkillsModule,
     JobsModule
   ]

--- a/apps/api/src/assets/assets.controller.ts
+++ b/apps/api/src/assets/assets.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Param, Req, Res } from "@nestjs/common";
+import { RequestWithHeaders, requireSessionUser } from "../auth/session";
+import { AssetsService } from "./assets.service";
+
+interface AssetResponse {
+  setHeader(name: string, value: number | string): void;
+  status(code: number): AssetResponse;
+  end(body: Buffer): void;
+}
+
+@Controller("assets")
+export class AssetsController {
+  constructor(private readonly assets: AssetsService) {}
+
+  @Get(":assetId/file")
+  async getOutputAssetFile(
+    @Param("assetId") assetId: string,
+    @Req() req: RequestWithHeaders,
+    @Res() res: AssetResponse
+  ): Promise<void> {
+    const user = requireSessionUser(req);
+    const file = await this.assets.getOutputImageFile(assetId, user.userId);
+    res.setHeader("Content-Type", file.mimeType);
+    res.setHeader("Content-Length", file.byteSize);
+    res.setHeader("Cache-Control", "private, no-store");
+    res.setHeader("Content-Disposition", `inline; filename="${file.fileName}"`);
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.status(200).end(file.bytes);
+  }
+}

--- a/apps/api/src/assets/assets.module.ts
+++ b/apps/api/src/assets/assets.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { DbModule } from "../db/db.module";
+import { WorkspacesModule } from "../workspaces/workspaces.module";
+import { AssetsController } from "./assets.controller";
+import { AssetsService } from "./assets.service";
+
+@Module({
+  imports: [DbModule, WorkspacesModule],
+  controllers: [AssetsController],
+  providers: [AssetsService]
+})
+export class AssetsModule {}

--- a/apps/api/src/assets/assets.service.ts
+++ b/apps/api/src/assets/assets.service.ts
@@ -1,0 +1,64 @@
+import { ForbiddenException, Injectable, NotFoundException } from "@nestjs/common";
+import { Inject } from "@nestjs/common";
+import { eq } from "drizzle-orm";
+import { readFile } from "node:fs/promises";
+import { resolve, sep } from "node:path";
+import { DB } from "../db/db.module";
+import { assets } from "../db/schema";
+import { AppDb } from "../db/types";
+import { WorkspacesService } from "../workspaces/workspaces.service";
+
+export interface AssetFile {
+  bytes: Buffer;
+  fileName: string;
+  mimeType: string;
+  byteSize: number;
+}
+
+@Injectable()
+export class AssetsService {
+  constructor(
+    private readonly workspaces: WorkspacesService,
+    @Inject(DB) private readonly db: AppDb
+  ) {}
+
+  async getOutputImageFile(assetId: string, userId: string): Promise<AssetFile> {
+    const [asset] = await this.db.select().from(assets).where(eq(assets.id, assetId)).limit(1);
+    if (!asset) {
+      throw new NotFoundException("Asset not found");
+    }
+    await this.workspaces.assertMember(asset.workspaceId, userId);
+    if (asset.kind !== "output-image") {
+      throw new ForbiddenException("Asset cannot be served as an output image");
+    }
+    const filePath = this.resolveAssetPath(asset.storagePath);
+    const bytes = await readFile(filePath);
+    return {
+      bytes,
+      fileName: `generated-${asset.sha256.slice(0, 12)}.${this.extensionForMimeType(asset.mimeType)}`,
+      mimeType: asset.mimeType,
+      byteSize: bytes.length
+    };
+  }
+
+  private resolveAssetPath(storagePath: string): string {
+    const root = resolve(this.assetRoot());
+    const filePath = resolve(root, storagePath);
+    if (filePath !== root && filePath.startsWith(`${root}${sep}`)) {
+      return filePath;
+    }
+    throw new ForbiddenException("Asset path is outside storage root");
+  }
+
+  private assetRoot(): string {
+    return process.env.ASSET_STORAGE_DIR ?? ".data/assets";
+  }
+
+  private extensionForMimeType(mimeType: string): string {
+    if (mimeType === "image/jpeg") return "jpg";
+    if (mimeType === "image/gif") return "gif";
+    if (mimeType === "image/webp") return "webp";
+    if (mimeType === "image/png") return "png";
+    return "bin";
+  }
+}

--- a/apps/api/src/jobs/job.types.ts
+++ b/apps/api/src/jobs/job.types.ts
@@ -51,7 +51,7 @@ export class JobOutput {
   sha256: string;
 
   @Field()
-  storagePath: string;
+  assetUrl: string;
 
   @Field()
   createdAt: string;

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -270,7 +270,7 @@ export class JobsService {
       mimeType: asset.mimeType,
       byteSize: asset.byteSize,
       sha256: asset.sha256,
-      storagePath: asset.storagePath,
+      assetUrl: `/assets/${asset.id}/file`,
       createdAt: row.createdAt.toISOString()
     };
   }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -53,7 +53,7 @@ interface GenerationJobOutput {
   mimeType: string;
   byteSize: number;
   sha256: string;
-  storagePath: string;
+  assetUrl: string;
 }
 
 interface GenerationJobEvent {
@@ -595,9 +595,23 @@ export function App() {
                       <span>{job.prompt}</span>
                       {latestEvent?.message ? <span>{latestEvent.message}</span> : null}
                       {job.outputs.map((output) => (
-                        <span key={output.id}>
-                          {output.label} - {output.mimeType} - {output.byteSize} bytes
-                        </span>
+                        <div className="job-output" key={output.id}>
+                          {output.mimeType.startsWith("image/") ? (
+                            <img
+                              alt={`${output.label} generated image`}
+                              className="job-output-image"
+                              src={resolveApiUrl(output.assetUrl)}
+                            />
+                          ) : null}
+                          <div className="job-output-meta">
+                            <span>
+                              {output.label} - {output.mimeType} - {output.byteSize} bytes
+                            </span>
+                            <a href={resolveApiUrl(output.assetUrl)} target="_blank" rel="noreferrer">
+                              Open image
+                            </a>
+                          </div>
+                        </div>
                       ))}
                     </article>
                   );
@@ -676,4 +690,9 @@ function bytesToBase64(bytes: Uint8Array): string {
     binary += String.fromCharCode(byte);
   });
   return btoa(binary);
+}
+
+function resolveApiUrl(path: string): string {
+  const graphqlUrl = import.meta.env.VITE_GRAPHQL_URL ?? "http://localhost:4000/graphql";
+  return new URL(path, graphqlUrl).toString();
 }

--- a/apps/web/src/graphql.ts
+++ b/apps/web/src/graphql.ts
@@ -140,7 +140,7 @@ export const GENERATION_JOBS_QUERY = gql`
         mimeType
         byteSize
         sha256
-        storagePath
+        assetUrl
         createdAt
       }
     }
@@ -181,7 +181,7 @@ export const RUN_IMAGE_GENERATION_JOB = gql`
         mimeType
         byteSize
         sha256
-        storagePath
+        assetUrl
       }
     }
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -320,6 +320,35 @@ button {
   overflow-wrap: anywhere;
 }
 
+.job-output {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+  margin-top: 4px;
+}
+
+.job-output-image {
+  width: 96px;
+  aspect-ratio: 1;
+  border: 1px solid #e2e9e5;
+  border-radius: 8px;
+  background: #f8faf8;
+  object-fit: contain;
+}
+
+.job-output-meta {
+  display: grid;
+  gap: 6px;
+}
+
+.job-output-meta a {
+  color: #245c4f;
+  font-size: 0.86rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
 .member-item {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 106px auto;
@@ -380,5 +409,13 @@ button {
 
   .member-item {
     grid-template-columns: 1fr;
+  }
+
+  .job-output {
+    grid-template-columns: 72px minmax(0, 1fr);
+  }
+
+  .job-output-image {
+    width: 72px;
   }
 }

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -1,4 +1,4 @@
-import { expect, Page, test } from "@playwright/test";
+import { expect, Locator, Page, test } from "@playwright/test";
 import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer, Server } from "node:http";
@@ -397,6 +397,12 @@ Always produce a sharp product image.
       await expect(page.getByLabel("Generation history")).toContainText("Job succeeded");
       await expect(page.getByLabel("Generation history")).toContainText(prompt);
       await expect(page.getByLabel("Generation history")).toContainText("generated-image - image/png");
+      const image = page.getByAltText("generated-image generated image").first();
+      await expect(image).toBeVisible();
+      const fetchedImage = await fetchElementImage(page, image);
+      expect(fetchedImage.status).toBe(200);
+      expect(fetchedImage.contentType).toContain("image/png");
+      expect(fetchedImage.bytes.equals(outputBytes)).toBe(true);
       expect(mock.requests[0]?.headers.authorization).toBe("Bearer mock-secret-key");
       expect(mock.requests[0]?.body.model).toBe("gpt-mock-responses");
       expect(mock.requests[0]?.body.stream).toBe(true);
@@ -526,6 +532,9 @@ description: Viewer block skill.
       await page.getByRole("button", { name: "Run Generation" }).click();
       await expect.poll(() => mock.requests.length).toBe(1);
       await expect(page.getByLabel("Generation history")).toContainText(historyPrompt);
+      const ownerImage = page.getByAltText("generated-image generated image").first();
+      await expect(ownerImage).toBeVisible();
+      const ownerAssetUrl = await elementImageSrc(ownerImage);
       await page.getByLabel("Member email").fill(accounts[1].email);
       await page.getByLabel("New member role").selectOption("viewer");
       await page.getByRole("button", { name: "Add Member" }).click();
@@ -536,6 +545,11 @@ description: Viewer block skill.
       await page.getByLabel("Active workspace").selectOption(ownerWorkspaceId);
       await expect(page.getByLabel("Generation history")).toContainText(historyPrompt);
       await expect(page.getByLabel("Generation history")).toContainText("generated-image - image/png");
+      const viewerImage = page.getByAltText("generated-image generated image").first();
+      await expect(viewerImage).toBeVisible();
+      const viewerFetch = await fetchUrlBytes(page, ownerAssetUrl);
+      expect(viewerFetch.status).toBe(200);
+      expect(viewerFetch.contentType).toContain("image/png");
       await page.getByLabel("Generation provider").selectOption({ label: "Viewer Block Provider" });
       await page.getByLabel("Generation skill").selectOption({ label: "viewer-block-skill" });
       await page.getByLabel("Image prompt").fill("Viewer should not run this.");
@@ -543,6 +557,11 @@ description: Viewer block skill.
 
       await expect(page.getByText("User cannot run workspace jobs")).toBeVisible();
       expect(mock.requests).toHaveLength(1);
+
+      await signOut(page);
+      await login(page, accounts[4]);
+      const nonMemberFetch = await fetchUrlBytes(page, ownerAssetUrl);
+      expect(nonMemberFetch.status).toBe(403);
     } finally {
       await mock.close();
     }
@@ -592,6 +611,7 @@ description: Shared history skill.
       await expect(page.getByLabel("Generation history")).toContainText(prompt);
       await expect(page.getByLabel("Generation history")).toContainText("Job succeeded");
       await expect(page.getByLabel("Generation history")).toContainText("generated-image - image/png");
+      await expect(page.getByAltText("generated-image generated image").first()).toBeVisible();
     } finally {
       await mock.close();
     }
@@ -785,6 +805,35 @@ async function uploadSkillFromUi(page: Page, fileName: string, content: string):
   if (skillName) {
     await expect(page.getByText(`Indexed ${skillName}`)).toBeVisible();
   }
+}
+
+async function fetchElementImage(page: Page, locator: Locator) {
+  return fetchUrlBytes(page, await elementImageSrc(locator));
+}
+
+async function elementImageSrc(locator: Locator): Promise<string> {
+  const src = await locator.getAttribute("src");
+  if (!src) {
+    throw new Error("Expected generated image to have a src");
+  }
+  return src;
+}
+
+async function fetchUrlBytes(page: Page, url: string): Promise<{ bytes: Buffer; contentType: string; status: number }> {
+  const result = await page.evaluate(async (imageUrl) => {
+    const response = await fetch(imageUrl, { cache: "no-store", credentials: "include" });
+    const bytes = Array.from(new Uint8Array(await response.arrayBuffer()));
+    return {
+      bytes,
+      contentType: response.headers.get("content-type") ?? "",
+      status: response.status
+    };
+  }, url);
+  return {
+    bytes: Buffer.from(result.bytes),
+    contentType: result.contentType,
+    status: result.status
+  };
 }
 
 async function selectValueForLabel(page: Page, label: string, optionLabel: string): Promise<string> {


### PR DESCRIPTION
Closes #15

## Summary

- Add an authenticated output-image asset file endpoint with workspace membership checks and path safety.
- Return `assetUrl` in job outputs and stop using browser-facing `storagePath`.
- Render generated image previews and open links in workspace generation history.
- Extend Playwright coverage for exact output bytes, viewer reads, and non-member rejection.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm test:e2e`

## Closeout

- [x] Issue body acceptance criteria are complete.
- [x] Canonical plan checklist is complete.
- [x] PR body matches issue #15 scope.

## CI

Skipped per repo instructions; local validation above is the gate for now.
