### PR TITLE
Manage workspace provider profiles

### DIFF
--- a/apps/api/src/provider-profiles/provider-profile.types.ts
+++ b/apps/api/src/provider-profiles/provider-profile.types.ts
@@ -33,6 +33,30 @@ export class ProviderProfileInput {
   apiKey: string;
 }
 
+@InputType()
+export class ProviderProfileUpdateInput {
+  @Field()
+  id: string;
+
+  @Field()
+  displayName: string;
+
+  @Field()
+  baseUrl: string;
+
+  @Field()
+  defaultModel: string;
+
+  @Field({ nullable: true })
+  defaultImageModel?: string;
+
+  @Field(() => [String])
+  capabilities: string[];
+
+  @Field({ nullable: true })
+  apiKey?: string;
+}
+
 @ObjectType()
 export class ProviderProfile {
   @Field()

--- a/apps/api/src/provider-profiles/provider-profiles.resolver.ts
+++ b/apps/api/src/provider-profiles/provider-profiles.resolver.ts
@@ -1,7 +1,7 @@
 import { Args, Context, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { RequestWithHeaders } from "../auth/session";
 import { currentUserId } from "../workspaces/workspaces.resolver";
-import { ProviderProfile, ProviderProfileInput } from "./provider-profile.types";
+import { ProviderProfile, ProviderProfileInput, ProviderProfileUpdateInput } from "./provider-profile.types";
 import { ProviderProfilesService } from "./provider-profiles.service";
 
 @Resolver(() => ProviderProfile)
@@ -22,5 +22,21 @@ export class ProviderProfilesResolver {
     @Context("req") req: RequestWithHeaders
   ): Promise<ProviderProfile> {
     return this.providerProfileService.create(input, currentUserId(req));
+  }
+
+  @Mutation(() => ProviderProfile)
+  updateProviderProfile(
+    @Args("input", { type: () => ProviderProfileUpdateInput }) input: ProviderProfileUpdateInput,
+    @Context("req") req: RequestWithHeaders
+  ): Promise<ProviderProfile> {
+    return this.providerProfileService.update(input, currentUserId(req));
+  }
+
+  @Mutation(() => Boolean)
+  deleteProviderProfile(
+    @Args("id", { type: () => String }) id: string,
+    @Context("req") req: RequestWithHeaders
+  ): Promise<boolean> {
+    return this.providerProfileService.delete(id, currentUserId(req));
   }
 }

--- a/apps/api/src/provider-profiles/provider-profiles.service.ts
+++ b/apps/api/src/provider-profiles/provider-profiles.service.ts
@@ -30,6 +30,7 @@ const providerProfileUpdateSchema = z.object({
   capabilities: z.array(z.string()),
   apiKey: z.string().min(1).nullish()
 });
+const providerProfileIdSchema = z.string().uuid();
 
 type StoredProviderProfile = ProviderProfile & {
   encryptedApiKey: string;
@@ -43,7 +44,7 @@ export class ProviderProfilesService {
   ) {}
 
   async create(input: ProviderProfileInput, userId: string): Promise<ProviderProfile> {
-    await this.assertWorkspaceMember(input.workspaceId, userId);
+    await this.assertCanWriteProviders(input.workspaceId, userId);
     providerProfileInputSchema.parse({
       ...input,
       providerType: "openai-compatible"
@@ -83,7 +84,7 @@ export class ProviderProfilesService {
     if (!existing) {
       throw new NotFoundException("Provider profile not found");
     }
-    await this.assertWorkspaceMember(existing.workspaceId, userId);
+    await this.assertCanWriteProviders(existing.workspaceId, userId);
     const [profile] = await this.db
       .update(providerProfiles)
       .set({
@@ -104,12 +105,13 @@ export class ProviderProfilesService {
   }
 
   async delete(id: string, userId: string): Promise<boolean> {
-    const [profile] = await this.db.select().from(providerProfiles).where(eq(providerProfiles.id, id)).limit(1);
+    const providerId = providerProfileIdSchema.parse(id);
+    const [profile] = await this.db.select().from(providerProfiles).where(eq(providerProfiles.id, providerId)).limit(1);
     if (!profile) {
       throw new NotFoundException("Provider profile not found");
     }
-    await this.assertWorkspaceMember(profile.workspaceId, userId);
-    await this.db.delete(providerProfiles).where(eq(providerProfiles.id, id));
+    await this.assertCanWriteProviders(profile.workspaceId, userId);
+    await this.db.delete(providerProfiles).where(eq(providerProfiles.id, providerId));
     return true;
   }
 
@@ -132,6 +134,10 @@ export class ProviderProfilesService {
 
   private async assertWorkspaceMember(workspaceId: string, userId: string): Promise<void> {
     await this.workspaces.assertMember(workspaceId, userId);
+  }
+
+  private async assertCanWriteProviders(workspaceId: string, userId: string): Promise<void> {
+    await this.workspaces.assertCanWriteProviders(workspaceId, userId);
   }
 
   private encryptForStorage(value: string): string {

--- a/apps/api/src/provider-profiles/provider-profiles.service.ts
+++ b/apps/api/src/provider-profiles/provider-profiles.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, InternalServerErrorException } from "@nestjs/common";
+import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from "@nestjs/common";
 import { Inject } from "@nestjs/common";
 import { createCipheriv, createDecipheriv, createHash, randomBytes, randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
@@ -8,7 +8,7 @@ import { providerProfiles } from "../db/schema";
 import { AppDb } from "../db/types";
 import { isoNow } from "../common/date";
 import { WorkspacesService } from "../workspaces/workspaces.service";
-import { ProviderProfile, ProviderProfileInput, ProviderTypeGql } from "./provider-profile.types";
+import { ProviderProfile, ProviderProfileInput, ProviderProfileUpdateInput, ProviderTypeGql } from "./provider-profile.types";
 
 const providerProfileInputSchema = z.object({
   workspaceId: z.string().uuid(),
@@ -19,6 +19,16 @@ const providerProfileInputSchema = z.object({
   defaultImageModel: z.string().min(1).max(120).optional(),
   capabilities: z.array(z.string()),
   apiKey: z.string().min(1)
+});
+
+const providerProfileUpdateSchema = z.object({
+  id: z.string().uuid(),
+  displayName: z.string().min(1).max(80),
+  baseUrl: z.string().url(),
+  defaultModel: z.string().min(1).max(120),
+  defaultImageModel: z.string().min(1).max(120).optional(),
+  capabilities: z.array(z.string()),
+  apiKey: z.string().min(1).optional()
 });
 
 type StoredProviderProfile = ProviderProfile & {
@@ -65,6 +75,42 @@ export class ProviderProfilesService {
       .from(providerProfiles)
       .where(eq(providerProfiles.workspaceId, workspaceId));
     return rows.map((row) => this.toProviderProfile(row));
+  }
+
+  async update(input: ProviderProfileUpdateInput, userId: string): Promise<ProviderProfile> {
+    const parsed = providerProfileUpdateSchema.parse(input);
+    const existing = await this.getStored(parsed.id);
+    if (!existing) {
+      throw new NotFoundException("Provider profile not found");
+    }
+    await this.assertWorkspaceMember(existing.workspaceId, userId);
+    const [profile] = await this.db
+      .update(providerProfiles)
+      .set({
+        displayName: parsed.displayName,
+        baseUrl: parsed.baseUrl,
+        defaultModel: parsed.defaultModel,
+        defaultImageModel: parsed.defaultImageModel,
+        capabilities: parsed.capabilities,
+        ...(parsed.apiKey ? { encryptedApiKey: this.encryptForStorage(parsed.apiKey) } : {}),
+        updatedAt: new Date()
+      })
+      .where(eq(providerProfiles.id, parsed.id))
+      .returning();
+    if (!profile) {
+      throw new Error("Provider profile update failed");
+    }
+    return this.toProviderProfile(profile);
+  }
+
+  async delete(id: string, userId: string): Promise<boolean> {
+    const [profile] = await this.db.select().from(providerProfiles).where(eq(providerProfiles.id, id)).limit(1);
+    if (!profile) {
+      throw new NotFoundException("Provider profile not found");
+    }
+    await this.assertWorkspaceMember(profile.workspaceId, userId);
+    await this.db.delete(providerProfiles).where(eq(providerProfiles.id, id));
+    return true;
   }
 
   async getStored(id: string): Promise<StoredProviderProfile | undefined> {

--- a/apps/api/src/provider-profiles/provider-profiles.service.ts
+++ b/apps/api/src/provider-profiles/provider-profiles.service.ts
@@ -28,7 +28,7 @@ const providerProfileUpdateSchema = z.object({
   defaultModel: z.string().min(1).max(120),
   defaultImageModel: z.string().min(1).max(120).optional(),
   capabilities: z.array(z.string()),
-  apiKey: z.string().min(1).optional()
+  apiKey: z.string().min(1).nullish()
 });
 
 type StoredProviderProfile = ProviderProfile & {

--- a/apps/api/src/workspaces/workspaces.service.ts
+++ b/apps/api/src/workspaces/workspaces.service.ts
@@ -9,6 +9,7 @@ import { Workspace, WorkspaceMember, WorkspaceMembership } from "./workspace.typ
 
 const membershipManagerRoles = new Set<WorkspaceMembership["role"]>(["owner", "admin"]);
 const jobWriterRoles = new Set<WorkspaceMembership["role"]>(["owner", "admin", "member"]);
+const providerWriterRoles = new Set<WorkspaceMembership["role"]>(["owner", "admin"]);
 
 @Injectable()
 export class WorkspacesService {
@@ -65,6 +66,13 @@ export class WorkspacesService {
     const membership = await this.findMembership(workspaceId, userId);
     if (!membership || !jobWriterRoles.has(membership.role)) {
       throw new ForbiddenException("User cannot run workspace jobs");
+    }
+  }
+
+  async assertCanWriteProviders(workspaceId: string, userId: string): Promise<void> {
+    const membership = await this.findMembership(workspaceId, userId);
+    if (!membership || !providerWriterRoles.has(membership.role)) {
+      throw new ForbiddenException("User cannot manage workspace providers");
     }
   }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,7 @@ import {
   ADD_WORKSPACE_MEMBER,
   CURRENT_USER_QUERY,
   CREATE_PROVIDER_PROFILE,
+  DELETE_PROVIDER_PROFILE,
   FINISH_PASSKEY_AUTHENTICATION,
   FINISH_PASSKEY_REGISTRATION,
   GENERATION_JOBS_QUERY,
@@ -19,6 +20,7 @@ import {
   START_PASSKEY_AUTHENTICATION,
   START_PASSKEY_REGISTRATION,
   UPLOAD_SKILL,
+  UPDATE_PROVIDER_PROFILE,
   UPDATE_WORKSPACE_MEMBER_ROLE,
   WORKSPACE_MEMBERS_QUERY,
   WORKSPACES_QUERY
@@ -127,7 +129,9 @@ export function App() {
   const [providerName, setProviderName] = useState("Local OpenAI Compatible");
   const [providerBaseUrl, setProviderBaseUrl] = useState("https://api.example.test/v1");
   const [providerModel, setProviderModel] = useState("gpt-image-test");
+  const [providerImageModel, setProviderImageModel] = useState("gpt-image-test");
   const [providerApiKey, setProviderApiKey] = useState("test-key");
+  const [editingProviderId, setEditingProviderId] = useState("");
   const [memberEmail, setMemberEmail] = useState("tester2@example.test");
   const [memberRole, setMemberRole] = useState<WorkspaceRole>("member");
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
@@ -147,6 +151,8 @@ export function App() {
   const [startPasskeyAuthenticationMutation] = useMutation(START_PASSKEY_AUTHENTICATION);
   const [finishPasskeyAuthenticationMutation] = useMutation(FINISH_PASSKEY_AUTHENTICATION);
   const [createProviderProfile, providerMutation] = useMutation(CREATE_PROVIDER_PROFILE);
+  const [updateProviderProfile, updateProviderMutation] = useMutation(UPDATE_PROVIDER_PROFILE);
+  const [deleteProviderProfile, deleteProviderMutation] = useMutation(DELETE_PROVIDER_PROFILE);
   const [uploadSkill, skillMutation] = useMutation(UPLOAD_SKILL);
   const [runGenerationJob, generationMutation] = useMutation<RunGenerationData>(RUN_IMAGE_GENERATION_JOB);
   const [addWorkspaceMember, addMemberMutation] = useMutation(ADD_WORKSPACE_MEMBER);
@@ -183,13 +189,13 @@ export function App() {
   const jobRows = generationJobs.data?.generationJobs ?? [];
   const selectedProviderId = providerRows.some((profile) => profile.id === generationProviderId)
     ? generationProviderId
-    : providerRows[0]?.id || "";
+    : "";
   const selectedSkillId = skillRows.some((skill) => skill.id === generationSkillId)
     ? generationSkillId
-    : skillRows[0]?.id || "";
+    : "";
   const currentUserName = currentUser?.displayName ?? "Loading user";
   const loginError = loginState.error?.message;
-  const providerError = providerMutation.error?.message;
+  const providerError = providerMutation.error?.message ?? updateProviderMutation.error?.message ?? deleteProviderMutation.error?.message;
   const generationError = generationMutation.error?.message;
   const memberError = addMemberMutation.error?.message ?? updateMemberMutation.error?.message ?? removeMemberMutation.error?.message;
   const skillResult = skillMutation.data?.uploadSkill;
@@ -198,6 +204,7 @@ export function App() {
   useEffect(() => {
     setGenerationProviderId("");
     setGenerationSkillId("");
+    setEditingProviderId("");
   }, [activeWorkspace?.id]);
 
   async function handleLogin(event: FormEvent<HTMLFormElement>) {
@@ -254,22 +261,71 @@ export function App() {
   async function handleProviderSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!activeWorkspace) return;
-    await createProviderProfile({
-      variables: {
-        input: {
-          workspaceId: activeWorkspace.id,
-          displayName: providerName,
-          providerType: "OPENAI_COMPATIBLE",
-          baseUrl: providerBaseUrl,
-          defaultModel: providerModel,
-          defaultImageModel: providerModel,
-          capabilities: ["image-generate", "tools"],
-          apiKey: providerApiKey
-        }
-      },
-      refetchQueries: [{ query: PROVIDER_PROFILES_QUERY, variables: { workspaceId: activeWorkspace.id } }]
-    });
+    const input = {
+      displayName: providerName,
+      baseUrl: providerBaseUrl,
+      defaultModel: providerModel,
+      defaultImageModel: providerImageModel || providerModel,
+      capabilities: ["image-generate", "tools"]
+    };
+    if (editingProviderId) {
+      await updateProviderProfile({
+        variables: {
+          input: {
+            id: editingProviderId,
+            ...input,
+            ...(providerApiKey ? { apiKey: providerApiKey } : {})
+          }
+        },
+        refetchQueries: [{ query: PROVIDER_PROFILES_QUERY, variables: { workspaceId: activeWorkspace.id } }]
+      });
+    } else {
+      await createProviderProfile({
+        variables: {
+          input: {
+            workspaceId: activeWorkspace.id,
+            providerType: "OPENAI_COMPATIBLE",
+            ...input,
+            apiKey: providerApiKey
+          }
+        },
+        refetchQueries: [{ query: PROVIDER_PROFILES_QUERY, variables: { workspaceId: activeWorkspace.id } }]
+      });
+    }
     setProviderApiKey("");
+  }
+
+  function handleEditProvider(profile: ProviderProfile) {
+    setEditingProviderId(profile.id);
+    setProviderName(profile.displayName);
+    setProviderBaseUrl(profile.baseUrl);
+    setProviderModel(profile.defaultModel);
+    setProviderImageModel(profile.defaultImageModel ?? profile.defaultModel);
+    setProviderApiKey("");
+  }
+
+  function handleNewProvider() {
+    setEditingProviderId("");
+    setProviderName("Local OpenAI Compatible");
+    setProviderBaseUrl("https://api.example.test/v1");
+    setProviderModel("gpt-image-test");
+    setProviderImageModel("gpt-image-test");
+    setProviderApiKey("test-key");
+  }
+
+  async function handleDeleteProvider() {
+    if (!activeWorkspace || !editingProviderId) return;
+    await deleteProviderProfile({
+      variables: { id: editingProviderId },
+      refetchQueries: [
+        { query: PROVIDER_PROFILES_QUERY, variables: { workspaceId: activeWorkspace.id } },
+        { query: GENERATION_JOBS_QUERY, variables: { workspaceId: activeWorkspace.id } }
+      ]
+    });
+    if (generationProviderId === editingProviderId) {
+      setGenerationProviderId("");
+    }
+    handleNewProvider();
   }
 
   async function handleSkillSubmit(event: FormEvent<HTMLFormElement>) {
@@ -476,6 +532,9 @@ export function App() {
                     <span>{profile.baseUrl}</span>
                     <span>{profile.defaultImageModel ?? profile.defaultModel}</span>
                     <span>{profile.capabilities.join(", ") || "None"}</span>
+                    <Button className="secondary-button compact-button" type="button" onClick={() => handleEditProvider(profile)}>
+                      Edit
+                    </Button>
                   </div>
                 ))
               )}
@@ -494,13 +553,32 @@ export function App() {
                 <input value={providerModel} onChange={(event) => setProviderModel(event.target.value)} />
               </label>
               <label>
+                Image tool model
+                <input value={providerImageModel} onChange={(event) => setProviderImageModel(event.target.value)} />
+              </label>
+              <label>
                 API key
-                <input value={providerApiKey} onChange={(event) => setProviderApiKey(event.target.value)} type="password" />
+                <input
+                  value={providerApiKey}
+                  onChange={(event) => setProviderApiKey(event.target.value)}
+                  placeholder={editingProviderId ? "Leave blank to keep existing key" : ""}
+                  type="password"
+                />
               </label>
               {providerError ? <p className="error-text">{providerError}</p> : null}
-              <Button className="primary-button" type="submit">
-                Save Provider
-              </Button>
+              <div className="form-actions">
+                <Button className="primary-button" type="submit">
+                  {editingProviderId ? "Update Provider" : "Save Provider"}
+                </Button>
+                <Button className="secondary-button" type="button" onClick={handleNewProvider}>
+                  New Provider
+                </Button>
+                {editingProviderId ? (
+                  <Button className="secondary-button danger-button" type="button" onClick={handleDeleteProvider}>
+                    Delete Provider
+                  </Button>
+                ) : null}
+              </div>
             </form>
           </section>
 
@@ -557,6 +635,7 @@ export function App() {
                   value={selectedProviderId}
                   onChange={(event) => setGenerationProviderId(event.target.value)}
                 >
+                  <option value="">Select provider</option>
                   {providerRows.map((profile) => (
                     <option key={profile.id} value={profile.id}>
                       {profile.displayName}
@@ -567,6 +646,7 @@ export function App() {
               <label>
                 Generation skill
                 <select value={selectedSkillId} onChange={(event) => setGenerationSkillId(event.target.value)}>
+                  <option value="">Select skill</option>
                   {skillRows.map((skill) => (
                     <option key={skill.id} value={skill.id}>
                       {skill.name}

--- a/apps/web/src/graphql.ts
+++ b/apps/web/src/graphql.ts
@@ -162,6 +162,27 @@ export const CREATE_PROVIDER_PROFILE = gql`
   }
 `;
 
+export const UPDATE_PROVIDER_PROFILE = gql`
+  mutation UpdateProviderProfile($input: ProviderProfileUpdateInput!) {
+    updateProviderProfile(input: $input) {
+      id
+      displayName
+      providerType
+      baseUrl
+      defaultModel
+      defaultImageModel
+      capabilities
+      hasApiKey
+    }
+  }
+`;
+
+export const DELETE_PROVIDER_PROFILE = gql`
+  mutation DeleteProviderProfile($id: String!) {
+    deleteProviderProfile(id: $id)
+  }
+`;
+
 export const RUN_IMAGE_GENERATION_JOB = gql`
   mutation RunImageGenerationJob($input: RunImageGenerationJobInput!) {
     runImageGenerationJob(input: $input) {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -192,6 +192,16 @@ button {
   border-color: #d5ddd8;
 }
 
+.compact-button {
+  min-height: 32px;
+  padding: 0 10px;
+}
+
+.danger-button {
+  color: #8d2d23;
+  border-color: #e8c8c2;
+}
+
 .content-grid {
   display: grid;
   grid-template-columns: minmax(0, 1.5fr) minmax(280px, 0.8fr);
@@ -237,7 +247,7 @@ button {
 
 .table-row {
   display: grid;
-  grid-template-columns: 1fr 1.3fr 1fr 1fr;
+  grid-template-columns: 1fr 1.3fr 1fr 1fr auto;
   gap: 12px;
   align-items: center;
   min-height: 48px;
@@ -277,6 +287,12 @@ button {
   display: grid;
   gap: 12px;
   margin-top: 18px;
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .stacked-form label,

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -337,6 +337,35 @@ description: Skill for updated provider profile.
     }
   });
 
+  test("blocks workspace viewers from editing provider profiles", async ({ page }) => {
+    await resetBrowserState(page);
+    await login(page, accounts[1]);
+    await signOut(page);
+    await login(page, accounts[0]);
+    await createProviderProfile(page, {
+      name: "Viewer Protected Provider",
+      baseUrl: "http://127.0.0.1:1/v1",
+      model: "viewer-protected-model",
+      apiKey: "viewer-protected-key"
+    });
+    await page.getByLabel("Member email").fill(accounts[1].email);
+    await page.getByLabel("New member role").selectOption("viewer");
+    await page.getByRole("button", { name: "Add Member" }).click();
+    const ownerWorkspaceId = await currentWorkspaceId(page);
+
+    await signOut(page);
+    await login(page, accounts[1]);
+    await page.getByLabel("Active workspace").selectOption(ownerWorkspaceId);
+    await expect(page.locator(".table-row").filter({ hasText: "Viewer Protected Provider" })).toBeVisible();
+    await page.locator(".table-row").filter({ hasText: "Viewer Protected Provider" }).getByRole("button", { name: "Edit" }).click();
+    await page.getByLabel("Provider name").fill("Viewer Mutated Provider");
+    await page.getByRole("button", { name: "Update Provider" }).click();
+    await expect(page.getByText("User cannot manage workspace providers")).toBeVisible();
+
+    await page.getByRole("button", { name: "Delete Provider" }).click();
+    await expect(page.getByText("User cannot manage workspace providers")).toBeVisible();
+  });
+
   test("indexes a valid Agent Skill from an uploaded Skill file", async ({ page }) => {
     await login(page);
     const filePath = await writeSkillFile("valid-skill.md", `---

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -309,8 +309,28 @@ description: Skill for updated provider profile.
       ]);
 
       await page.locator(".table-row").filter({ hasText: "Updated Provider" }).getByRole("button", { name: "Edit" }).click();
+      await page.getByLabel("Provider name").fill("Updated Provider No Key Rotation");
+      await page.getByLabel("Default model").fill("second-text-model");
+      await page.getByLabel("Image tool model").fill("second-image-model");
+      await page.getByLabel("API key").fill("");
+      await page.getByRole("button", { name: "Update Provider" }).click();
+      await expect(page.locator(".table-row").filter({ hasText: "Updated Provider No Key Rotation" })).toBeVisible();
+
+      const secondPrompt = `Keep the existing provider key ${Date.now()}.`;
+      await page.getByLabel("Generation provider").selectOption({ label: "Updated Provider No Key Rotation" });
+      await page.getByLabel("Generation skill").selectOption({ label: "editable-provider-skill" });
+      await page.getByLabel("Image prompt").fill(secondPrompt);
+      await page.getByRole("button", { name: "Run Generation" }).click();
+      await expect.poll(() => mock.requests.length).toBe(2);
+      expect(mock.requests[1]?.headers.authorization).toBe("Bearer updated-secret-key");
+      expect(mock.requests[1]?.body.model).toBe("second-text-model");
+      expect(mock.requests[1]?.body.tools).toEqual([
+        { type: "image_generation", model: "second-image-model", action: "generate" }
+      ]);
+
+      await page.locator(".table-row").filter({ hasText: "Updated Provider" }).getByRole("button", { name: "Edit" }).click();
       await page.getByRole("button", { name: "Delete Provider" }).click();
-      await expect(page.locator(".table-row").filter({ hasText: "Updated Provider" })).toHaveCount(0);
+      await expect(page.locator(".table-row").filter({ hasText: "Updated Provider No Key Rotation" })).toHaveCount(0);
       await expect(page.getByLabel("Generation provider")).toHaveValue("");
     } finally {
       await mock.close();

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -251,6 +251,7 @@ description: Scoped job skill.
     await page.getByLabel("Provider name").fill("Workspace Image Provider");
     await page.getByLabel("Base URL").fill("https://models.example.test/v1");
     await page.getByLabel("Default model").fill("gpt-image-workspace");
+    await page.getByLabel("Image tool model").fill("gpt-image-workspace");
     await page.getByLabel("API key").fill("super-secret-e2e-key");
     await page.getByRole("button", { name: "Save Provider" }).click();
 
@@ -258,6 +259,62 @@ description: Scoped job skill.
     await expect(page.getByText("https://models.example.test/v1")).toBeVisible();
     await expect(page.getByText("gpt-image-workspace")).toBeVisible();
     await expect(page.getByText("super-secret-e2e-key")).toHaveCount(0);
+  });
+
+  test("updates and deletes a workspace provider profile", async ({ page }) => {
+    const outputBytes = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+      "base64"
+    );
+    const mock = await startResponsesMock({ outputBytes });
+    try {
+      await login(page);
+      await createProviderProfile(page, {
+        name: "Editable Provider",
+        baseUrl: "http://127.0.0.1:1/v1",
+        model: "old-model",
+        apiKey: "old-secret-key"
+      });
+      await uploadSkillFromUi(page, "editable-provider-skill.md", `---
+name: editable-provider-skill
+description: Skill for updated provider profile.
+---
+
+# Editable Provider Skill
+`);
+
+      const providerRow = page.locator(".table-row").filter({ hasText: "Editable Provider" });
+      await providerRow.getByRole("button", { name: "Edit" }).click();
+      await page.getByLabel("Provider name").fill("Updated Provider");
+      await page.getByLabel("Base URL").fill(mock.baseUrl);
+      await page.getByLabel("Default model").fill("updated-text-model");
+      await page.getByLabel("Image tool model").fill("updated-image-model");
+      await page.getByLabel("API key").fill("updated-secret-key");
+      await page.getByRole("button", { name: "Update Provider" }).click();
+
+      await expect(page.locator(".table-row").filter({ hasText: "Updated Provider" })).toBeVisible();
+      await expect(page.getByText("updated-image-model")).toBeVisible();
+      await expect(page.getByText("updated-secret-key")).toHaveCount(0);
+
+      const prompt = `Use the updated provider ${Date.now()}.`;
+      await page.getByLabel("Generation provider").selectOption({ label: "Updated Provider" });
+      await page.getByLabel("Generation skill").selectOption({ label: "editable-provider-skill" });
+      await page.getByLabel("Image prompt").fill(prompt);
+      await page.getByRole("button", { name: "Run Generation" }).click();
+      await expect.poll(() => mock.requests.length).toBe(1);
+      expect(mock.requests[0]?.headers.authorization).toBe("Bearer updated-secret-key");
+      expect(mock.requests[0]?.body.model).toBe("updated-text-model");
+      expect(mock.requests[0]?.body.tools).toEqual([
+        { type: "image_generation", model: "updated-image-model", action: "generate" }
+      ]);
+
+      await page.locator(".table-row").filter({ hasText: "Updated Provider" }).getByRole("button", { name: "Edit" }).click();
+      await page.getByRole("button", { name: "Delete Provider" }).click();
+      await expect(page.locator(".table-row").filter({ hasText: "Updated Provider" })).toHaveCount(0);
+      await expect(page.getByLabel("Generation provider")).toHaveValue("");
+    } finally {
+      await mock.close();
+    }
   });
 
   test("indexes a valid Agent Skill from an uploaded Skill file", async ({ page }) => {


### PR DESCRIPTION
Closes #19

## Summary

- Add update/delete provider profile mutations with owner/admin provider write checks, UUID delete validation, and write-only API key rotation.
- Add frontend provider edit/delete controls, explicit image tool model field, and empty generation selections to avoid stale fallback after deletion.
- Extend Playwright coverage for updating key/model/base URL, preserving blank-key updates, viewer write rejection, generating with updated config, deleting providers, and preserving no-secret rendering.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm test:e2e`

## Closeout

- [x] Issue body acceptance criteria are complete.
- [x] Canonical plan checklist is complete.
- [x] PR body matches issue #19 scope.

## CI

Skipped per repo instructions; local validation above is the gate for now.