### PR TITLE
Enforce skill upload write permissions

### DIFF
--- a/apps/api/src/skills/skills.service.ts
+++ b/apps/api/src/skills/skills.service.ts
@@ -54,7 +54,7 @@ export class SkillsService {
   }
 
   async upload(input: SkillUploadInput, userId: string): Promise<SkillUploadResult> {
-    await this.assertWorkspaceMember(input.workspaceId, userId);
+    await this.assertCanWriteSkills(input.workspaceId, userId);
     const file = this.decodeUpload(input);
     const parsed = parseSkillMd(file.skillMdContent);
     const name = parsed.name || "Invalid Skill";
@@ -385,6 +385,10 @@ export class SkillsService {
 
   private async assertWorkspaceMember(workspaceId: string, userId: string): Promise<void> {
     await this.workspaces.assertMember(workspaceId, userId);
+  }
+
+  private async assertCanWriteSkills(workspaceId: string, userId: string): Promise<void> {
+    await this.workspaces.assertCanWriteSkills(workspaceId, userId);
   }
 
   private toSkill(row: typeof skills.$inferSelect): Skill {

--- a/apps/api/src/workspaces/workspaces.service.ts
+++ b/apps/api/src/workspaces/workspaces.service.ts
@@ -10,6 +10,7 @@ import { Workspace, WorkspaceMember, WorkspaceMembership } from "./workspace.typ
 const membershipManagerRoles = new Set<WorkspaceMembership["role"]>(["owner", "admin"]);
 const jobWriterRoles = new Set<WorkspaceMembership["role"]>(["owner", "admin", "member"]);
 const providerWriterRoles = new Set<WorkspaceMembership["role"]>(["owner", "admin"]);
+const skillWriterRoles = new Set<WorkspaceMembership["role"]>(["owner", "admin", "member"]);
 
 @Injectable()
 export class WorkspacesService {
@@ -73,6 +74,13 @@ export class WorkspacesService {
     const membership = await this.findMembership(workspaceId, userId);
     if (!membership || !providerWriterRoles.has(membership.role)) {
       throw new ForbiddenException("User cannot manage workspace providers");
+    }
+  }
+
+  async assertCanWriteSkills(workspaceId: string, userId: string): Promise<void> {
+    const membership = await this.findMembership(workspaceId, userId);
+    if (!membership || !skillWriterRoles.has(membership.role)) {
+      throw new ForbiddenException("User cannot upload workspace skills");
     }
   }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -198,6 +198,7 @@ export function App() {
   const providerError = providerMutation.error?.message ?? updateProviderMutation.error?.message ?? deleteProviderMutation.error?.message;
   const generationError = generationMutation.error?.message;
   const memberError = addMemberMutation.error?.message ?? updateMemberMutation.error?.message ?? removeMemberMutation.error?.message;
+  const skillError = skillMutation.error?.message;
   const skillResult = skillMutation.data?.uploadSkill;
   const skillErrors = useMemo(() => skillResult?.version.validationErrors ?? [], [skillResult]);
 
@@ -615,6 +616,7 @@ export function App() {
                   {skillErrors.length > 0 ? skillErrors.join(", ") : `Indexed ${skillResult.version.name}`}
                 </p>
               ) : null}
+              {skillError ? <p className="error-text">{skillError}</p> : null}
               <Button className="primary-button" type="submit">
                 Upload Skill
               </Button>

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -384,6 +384,44 @@ version: 2.0.0
     await expectStoredSkillArchive(filePath);
   });
 
+  test("blocks workspace viewers from uploading Agent Skills", async ({ page }) => {
+    await resetBrowserState(page);
+    await login(page, accounts[1]);
+    await signOut(page);
+    await login(page, accounts[0]);
+    await uploadSkillFromUi(page, "viewer-readable-skill.md", `---
+name: viewer-readable-skill
+description: Skill visible to viewer collaborators.
+version: 1.0.0
+---
+
+# Viewer Readable Skill
+`);
+    await page.getByLabel("Member email").fill(accounts[1].email);
+    await page.getByLabel("New member role").selectOption("viewer");
+    await page.getByRole("button", { name: "Add Member" }).click();
+    const ownerWorkspaceId = await currentWorkspaceId(page);
+
+    await signOut(page);
+    await login(page, accounts[1]);
+    await page.getByLabel("Active workspace").selectOption(ownerWorkspaceId);
+    await expect(page.locator(".skill-item").filter({ hasText: "viewer-readable-skill" })).toBeVisible();
+
+    const filePath = await writeSkillFile("viewer-upload-skill.md", `---
+name: viewer-upload-skill
+description: Viewer upload should be rejected.
+version: 1.0.0
+---
+
+# Viewer Upload Skill
+`);
+    await page.getByLabel("Skill file").setInputFiles(filePath);
+    await page.getByRole("button", { name: "Upload Skill" }).click();
+
+    await expect(page.getByText("User cannot upload workspace skills")).toBeVisible();
+    await expect(page.locator(".skill-item").filter({ hasText: "viewer-upload-skill" })).toHaveCount(0);
+  });
+
   test("indexes a zipped Agent Skill package and generates from its SKILL.md", async ({ page }) => {
     const outputBytes = Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",


### PR DESCRIPTION
Closes #21

## Summary

- Add owner/admin/member `skills:write` enforcement for Agent Skill uploads while keeping viewer skill listing readable.
- Surface skill upload GraphQL authorization errors in the frontend.
- Extend Playwright coverage for viewer read access plus upload rejection, while preserving existing markdown and zip upload flows.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm test:e2e`

## Closeout

- [x] Issue body acceptance criteria are complete.
- [x] Canonical plan checklist is complete.
- [x] PR body matches issue #21 scope.

## CI

Skipped per repo instructions; local validation above is the gate for now.