### PR TITLE
Include safe Agent Skill package reference files in generation context

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Initial roles:
 ## Agent Skills
 
 Uploaded skills follow the AI SDK Agent Skills directory model. Each package must include a `SKILL.md` file with frontmatter metadata. The backend indexes metadata and stores the original package/extracted directory reference, but this foundation slice does not execute uploaded code.
+For zipped packages, generation also includes bounded text files from safe support paths such as `references/` and text-like `assets/`; scripts and binary files are not executed or added to prompts.
 
 ## Validation
 
@@ -56,4 +57,3 @@ pnpm build
 ```
 
 CI is intentionally skipped for now.
-

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -10,16 +10,11 @@ import { DB } from "../db/db.module";
 import { assets, jobEvents, jobs, outputs, skills, skillVersions } from "../db/schema";
 import { AppDb } from "../db/types";
 import { ProviderProfilesService } from "../provider-profiles/provider-profiles.service";
-import { readSkillSupportFiles, SkillSupportFile } from "../skills/skill-package";
+import { readSkillSupportFiles, SkillSupportFile, skillSupportFileLimits } from "../skills/skill-package";
 import { WorkspacesService } from "../workspaces/workspaces.service";
 import { GenerationJob, JobEvent, JobOutput, RunImageGenerationJobInput } from "./job.types";
 
 const imageGenerationTimeoutMs = 600_000;
-const maxSkillPackageEntries = 100;
-const maxSkillPackageUncompressedBytes = 2 * 1024 * 1024;
-const maxSupportFiles = 12;
-const maxSupportFileBytes = 16 * 1024;
-const maxSupportTotalBytes = 64 * 1024;
 const imageGenerationJobInputSchema = z.object({
   workspaceId: z.string().uuid(),
   providerProfileId: z.string().uuid(),
@@ -173,13 +168,7 @@ export class JobsService {
       return { skillMd, supportFiles: [] };
     }
     const archiveBytes = await readFile(this.assetPath(skill.archiveAsset.storagePath));
-    const supportFiles = readSkillSupportFiles(archiveBytes, {
-      maxEntries: maxSkillPackageEntries,
-      maxTotalUncompressedBytes: maxSkillPackageUncompressedBytes,
-      maxFiles: maxSupportFiles,
-      maxFileBytes: maxSupportFileBytes,
-      maxTotalBytes: maxSupportTotalBytes
-    });
+    const supportFiles = readSkillSupportFiles(archiveBytes, skillSupportFileLimits);
     return { skillMd, supportFiles };
   }
 
@@ -199,7 +188,7 @@ export class JobsService {
         "",
         "<skill_support_files>",
         ...skillContext.supportFiles.flatMap((file) => [
-          `<file path="${file.path}">`,
+          `<file path="${this.escapePromptAttribute(file.path)}">`,
           file.content,
           "</file>",
           ""
@@ -214,6 +203,17 @@ export class JobsService {
       "User image request:",
       userPrompt
     ].join("\n");
+  }
+
+  private escapePromptAttribute(value: string): string {
+    return value
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/\r/g, "&#13;")
+      .replace(/\n/g, "&#10;")
+      .replace(/\t/g, "&#9;");
   }
 
   private async writeOutputAsset(workspaceId: string, ownerId: string, bytes: Buffer) {

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -10,10 +10,16 @@ import { DB } from "../db/db.module";
 import { assets, jobEvents, jobs, outputs, skills, skillVersions } from "../db/schema";
 import { AppDb } from "../db/types";
 import { ProviderProfilesService } from "../provider-profiles/provider-profiles.service";
+import { readSkillSupportFiles, SkillSupportFile } from "../skills/skill-package";
 import { WorkspacesService } from "../workspaces/workspaces.service";
 import { GenerationJob, JobEvent, JobOutput, RunImageGenerationJobInput } from "./job.types";
 
 const imageGenerationTimeoutMs = 600_000;
+const maxSkillPackageEntries = 100;
+const maxSkillPackageUncompressedBytes = 2 * 1024 * 1024;
+const maxSupportFiles = 12;
+const maxSupportFileBytes = 16 * 1024;
+const maxSupportTotalBytes = 64 * 1024;
 const imageGenerationJobInputSchema = z.object({
   workspaceId: z.string().uuid(),
   providerProfileId: z.string().uuid(),
@@ -58,8 +64,8 @@ export class JobsService {
     this.assertProviderCanGenerateImages(provider.capabilities);
     const skill = await this.getLatestValidSkillArchive(parsed.workspaceId, parsed.skillId);
     this.assertSkillCanGenerateImages(skill.version.permissions);
-    const skillMd = await readFile(this.assetPath(skill.asset.storagePath), "utf8");
-    const fullPrompt = this.buildGenerationPrompt(skillMd, parsed.prompt);
+    const skillContext = await this.loadSkillContext(skill);
+    const fullPrompt = this.buildGenerationPrompt(skillContext, parsed.prompt);
 
     const [job] = await this.db
       .insert(jobs)
@@ -117,7 +123,7 @@ export class JobsService {
 
   private async getLatestValidSkillArchive(workspaceId: string, skillId: string) {
     const [row] = await this.db
-      .select({ skill: skills, version: skillVersions, asset: assets })
+      .select({ skill: skills, version: skillVersions, archiveAsset: assets })
       .from(skills)
       .innerJoin(skillVersions, eq(skillVersions.id, skills.latestVersionId))
       .innerJoin(assets, eq(assets.id, skillVersions.archiveAssetId))
@@ -130,7 +136,10 @@ export class JobsService {
       throw new BadRequestException("Skill must have a valid latest version before generation");
     }
     if (!row.version.directoryAssetId) {
-      return row;
+      return {
+        ...row,
+        skillMdAsset: row.archiveAsset
+      };
     }
     const [directoryAsset] = await this.db
       .select()
@@ -142,7 +151,7 @@ export class JobsService {
     }
     return {
       ...row,
-      asset: directoryAsset
+      skillMdAsset: directoryAsset
     };
   }
 
@@ -158,14 +167,50 @@ export class JobsService {
     }
   }
 
-  private buildGenerationPrompt(skillMd: string, userPrompt: string): string {
-    return [
+  private async loadSkillContext(skill: Awaited<ReturnType<JobsService["getLatestValidSkillArchive"]>>) {
+    const skillMd = await readFile(this.assetPath(skill.skillMdAsset.storagePath), "utf8");
+    if (!skill.version.directoryAssetId) {
+      return { skillMd, supportFiles: [] };
+    }
+    const archiveBytes = await readFile(this.assetPath(skill.archiveAsset.storagePath));
+    const supportFiles = readSkillSupportFiles(archiveBytes, {
+      maxEntries: maxSkillPackageEntries,
+      maxTotalUncompressedBytes: maxSkillPackageUncompressedBytes,
+      maxFiles: maxSupportFiles,
+      maxFileBytes: maxSupportFileBytes,
+      maxTotalBytes: maxSupportTotalBytes
+    });
+    return { skillMd, supportFiles };
+  }
+
+  private buildGenerationPrompt(skillContext: { skillMd: string; supportFiles: SkillSupportFile[] }, userPrompt: string): string {
+    const sections = [
       "Use the following Agent Skill instructions for this image generation request.",
       "",
       "<skill_md>",
-      skillMd,
+      skillContext.skillMd,
       "</skill_md>",
-      "",
+      ""
+    ];
+
+    if (skillContext.supportFiles.length > 0) {
+      sections.push(
+        "Additional safe text files from the Agent Skill package:",
+        "",
+        "<skill_support_files>",
+        ...skillContext.supportFiles.flatMap((file) => [
+          `<file path="${file.path}">`,
+          file.content,
+          "</file>",
+          ""
+        ]),
+        "</skill_support_files>",
+        ""
+      );
+    }
+
+    return [
+      ...sections,
       "User image request:",
       userPrompt
     ].join("\n");

--- a/apps/api/src/skills/skill-package.ts
+++ b/apps/api/src/skills/skill-package.ts
@@ -1,0 +1,219 @@
+import { BadRequestException } from "@nestjs/common";
+import { inflateRawSync } from "node:zlib";
+
+export interface ZipEntryMetadata {
+  name: string;
+  compressionMethod: number;
+  flags: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  localHeaderOffset: number;
+}
+
+export interface SkillSupportFile {
+  path: string;
+  content: string;
+}
+
+export function readZipEntries(
+  bytes: Buffer,
+  limits: { maxEntries: number; maxTotalUncompressedBytes: number }
+): ZipEntryMetadata[] {
+  const eocdOffset = findEndOfCentralDirectory(bytes);
+  const diskNumber = bytes.readUInt16LE(eocdOffset + 4);
+  const centralDirDisk = bytes.readUInt16LE(eocdOffset + 6);
+  const entryCount = bytes.readUInt16LE(eocdOffset + 10);
+  const centralDirSize = bytes.readUInt32LE(eocdOffset + 12);
+  const centralDirOffset = bytes.readUInt32LE(eocdOffset + 16);
+  if (diskNumber !== 0 || centralDirDisk !== 0) {
+    throw new BadRequestException("Skill package must be a single-disk zip archive");
+  }
+  if (entryCount === 0xffff || centralDirSize === 0xffffffff || centralDirOffset === 0xffffffff) {
+    throw new BadRequestException("Skill package zip64 archives are not supported");
+  }
+  if (entryCount <= 0 || entryCount > limits.maxEntries) {
+    throw new BadRequestException(`Skill package must contain between 1 and ${limits.maxEntries} entries`);
+  }
+  if (centralDirOffset + centralDirSize > bytes.length) {
+    throw new BadRequestException("Skill package central directory is invalid");
+  }
+
+  const entries: ZipEntryMetadata[] = [];
+  let offset = centralDirOffset;
+  let totalUncompressedBytes = 0;
+  for (let index = 0; index < entryCount; index += 1) {
+    if (offset + 46 > bytes.length || bytes.readUInt32LE(offset) !== 0x02014b50) {
+      throw new BadRequestException("Skill package central directory is invalid");
+    }
+    const flags = bytes.readUInt16LE(offset + 8);
+    const compressionMethod = bytes.readUInt16LE(offset + 10);
+    const compressedSize = bytes.readUInt32LE(offset + 20);
+    const uncompressedSize = bytes.readUInt32LE(offset + 24);
+    const fileNameLength = bytes.readUInt16LE(offset + 28);
+    const extraLength = bytes.readUInt16LE(offset + 30);
+    const commentLength = bytes.readUInt16LE(offset + 32);
+    const localHeaderOffset = bytes.readUInt32LE(offset + 42);
+    const nameStart = offset + 46;
+    const nextOffset = nameStart + fileNameLength + extraLength + commentLength;
+    if (nextOffset > bytes.length) {
+      throw new BadRequestException("Skill package central directory is invalid");
+    }
+    if ((flags & 0x1) !== 0) {
+      throw new BadRequestException("Skill package encrypted entries are not supported");
+    }
+    if (![0, 8].includes(compressionMethod)) {
+      throw new BadRequestException("Skill package entry compression method is not supported");
+    }
+    const name = normalizeZipPath(bytes.subarray(nameStart, nameStart + fileNameLength).toString("utf8"));
+    if (!name) {
+      throw new BadRequestException("Skill package entries must have safe relative paths");
+    }
+    totalUncompressedBytes += uncompressedSize;
+    if (totalUncompressedBytes > limits.maxTotalUncompressedBytes) {
+      throw new BadRequestException("Skill package uncompressed content exceeds the 2MB limit");
+    }
+    if (localHeaderOffset + 30 > bytes.length || localHeaderOffset + compressedSize > bytes.length) {
+      throw new BadRequestException("Skill package local file header is invalid");
+    }
+    entries.push({ name, compressionMethod, flags, compressedSize, uncompressedSize, localHeaderOffset });
+    offset = nextOffset;
+  }
+  return entries;
+}
+
+export function readZipEntryBytes(bytes: Buffer, entry: ZipEntryMetadata, maxOutputLength: number): Buffer {
+  const offset = entry.localHeaderOffset;
+  if (bytes.readUInt32LE(offset) !== 0x04034b50) {
+    throw new BadRequestException("Skill package local file header is invalid");
+  }
+  const fileNameLength = bytes.readUInt16LE(offset + 26);
+  const extraLength = bytes.readUInt16LE(offset + 28);
+  const dataStart = offset + 30 + fileNameLength + extraLength;
+  const dataEnd = dataStart + entry.compressedSize;
+  if (dataEnd > bytes.length) {
+    throw new BadRequestException("Skill package local file data is invalid");
+  }
+  const compressedBytes = bytes.subarray(dataStart, dataEnd);
+  let output: Buffer;
+  try {
+    output =
+      entry.compressionMethod === 0
+        ? Buffer.from(compressedBytes)
+        : inflateRawSync(compressedBytes, { maxOutputLength });
+  } catch {
+    throw new BadRequestException("Skill package entry exceeds the allowed extracted size");
+  }
+  if (output.length !== entry.uncompressedSize) {
+    throw new BadRequestException("Skill package entry size metadata does not match content");
+  }
+  return output;
+}
+
+export function assertAllowedSkillMdLocation(path: string): void {
+  const parts = path.split("/");
+  if (parts.length > 2) {
+    throw new BadRequestException("Skill package SKILL.md must be at the root or inside one top-level folder");
+  }
+}
+
+export function readSkillSupportFiles(
+  bytes: Buffer,
+  limits: {
+    maxEntries: number;
+    maxTotalUncompressedBytes: number;
+    maxFiles: number;
+    maxFileBytes: number;
+    maxTotalBytes: number;
+  }
+): SkillSupportFile[] {
+  const entries = readZipEntries(bytes, limits);
+  const skillMdEntry = findSingleSkillMdEntry(entries);
+  assertAllowedSkillMdLocation(skillMdEntry.name);
+  const root = skillPackageRoot(skillMdEntry.name);
+  const supportFiles: SkillSupportFile[] = [];
+  let totalBytes = 0;
+
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const relativePath = relativeSupportPath(entry.name, root);
+    if (!relativePath || !isAllowedSupportPath(relativePath) || !isTextLikeSupportFile(relativePath)) {
+      continue;
+    }
+    if (entry.uncompressedSize <= 0 || entry.uncompressedSize > limits.maxFileBytes) {
+      continue;
+    }
+    if (supportFiles.length >= limits.maxFiles || totalBytes + entry.uncompressedSize > limits.maxTotalBytes) {
+      break;
+    }
+    const contentBytes = readZipEntryBytes(bytes, entry, limits.maxFileBytes + 1);
+    if (contentBytes.includes(0)) {
+      continue;
+    }
+    const content = contentBytes.toString("utf8");
+    if (content.includes("\uFFFD")) {
+      continue;
+    }
+    supportFiles.push({ path: relativePath, content });
+    totalBytes += contentBytes.length;
+  }
+
+  return supportFiles;
+}
+
+function findEndOfCentralDirectory(bytes: Buffer): number {
+  const minOffset = Math.max(0, bytes.length - 65_557);
+  for (let offset = bytes.length - 22; offset >= minOffset; offset -= 1) {
+    if (bytes.readUInt32LE(offset) === 0x06054b50) {
+      return offset;
+    }
+  }
+  throw new BadRequestException("Skill package must be a valid zip archive");
+}
+
+function findSingleSkillMdEntry(entries: ZipEntryMetadata[]): ZipEntryMetadata {
+  const skillMdEntries = entries.filter((entry) => entry.name.endsWith("/SKILL.md") || entry.name === "SKILL.md");
+  if (skillMdEntries.length === 0) {
+    throw new BadRequestException("Skill package must contain SKILL.md");
+  }
+  if (skillMdEntries.length > 1) {
+    throw new BadRequestException("Skill package must contain exactly one SKILL.md");
+  }
+  const skillMdEntry = skillMdEntries[0];
+  if (!skillMdEntry) {
+    throw new BadRequestException("Skill package must contain SKILL.md");
+  }
+  return skillMdEntry;
+}
+
+function normalizeZipPath(name: string): string {
+  const normalized = name.replace(/\\/g, "/").replace(/^\/+/, "");
+  const parts = normalized.split("/").filter(Boolean);
+  if (parts.length === 0 || parts.some((part) => part === "." || part === "..")) {
+    return "";
+  }
+  return parts.join("/");
+}
+
+function skillPackageRoot(skillMdPath: string): string {
+  const parts = skillMdPath.split("/");
+  return parts.length === 1 ? "" : parts[0] ?? "";
+}
+
+function relativeSupportPath(path: string, root: string): string | undefined {
+  if (!root) {
+    return path;
+  }
+  const prefix = `${root}/`;
+  return path.startsWith(prefix) ? path.slice(prefix.length) : undefined;
+}
+
+function isAllowedSupportPath(path: string): boolean {
+  const parts = path.split("/");
+  if (parts.length < 2 || parts.some((part) => part === "scripts")) {
+    return false;
+  }
+  return parts[0] === "references" || parts[0] === "assets";
+}
+
+function isTextLikeSupportFile(path: string): boolean {
+  return /\.(md|markdown|txt|text|json|ya?ml|csv|tsv|prompt)$/i.test(path);
+}

--- a/apps/api/src/skills/skill-package.ts
+++ b/apps/api/src/skills/skill-package.ts
@@ -220,10 +220,11 @@ function relativeSupportPath(path: string, root: string): string | undefined {
 
 function isAllowedSupportPath(path: string): boolean {
   const parts = path.split("/");
-  if (parts.length < 2 || parts.some((part) => part === "scripts")) {
+  const normalizedParts = parts.map((part) => part.toLowerCase());
+  if (normalizedParts.length < 2 || normalizedParts.some((part) => part === "scripts")) {
     return false;
   }
-  return parts[0] === "references" || parts[0] === "assets";
+  return normalizedParts[0] === "references" || normalizedParts[0] === "assets";
 }
 
 function isTextLikeSupportFile(path: string): boolean {

--- a/apps/api/src/skills/skill-package.ts
+++ b/apps/api/src/skills/skill-package.ts
@@ -15,6 +15,18 @@ export interface SkillSupportFile {
   content: string;
 }
 
+export const skillPackageArchiveLimits = {
+  maxEntries: 100,
+  maxTotalUncompressedBytes: 2 * 1024 * 1024
+};
+
+export const skillSupportFileLimits = {
+  ...skillPackageArchiveLimits,
+  maxFiles: 12,
+  maxFileBytes: 16 * 1024,
+  maxTotalBytes: 64 * 1024
+};
+
 export function readZipEntries(
   bytes: Buffer,
   limits: { maxEntries: number; maxTotalUncompressedBytes: number }

--- a/apps/api/src/skills/skills.service.ts
+++ b/apps/api/src/skills/skills.service.ts
@@ -9,14 +9,19 @@ import { assets, skills, skillVersions } from "../db/schema";
 import { AppDb } from "../db/types";
 import { WorkspacesService } from "../workspaces/workspaces.service";
 import { parseSkillMd } from "./skill-md.parser";
-import { assertAllowedSkillMdLocation, readZipEntries, readZipEntryBytes } from "./skill-package";
+import {
+  assertAllowedSkillMdLocation,
+  readSkillSupportFiles,
+  readZipEntries,
+  readZipEntryBytes,
+  skillPackageArchiveLimits,
+  skillSupportFileLimits
+} from "./skill-package";
 import { Skill, SkillUploadInput, SkillUploadResult, SkillVersion } from "./skill.types";
 
 const maxSkillUploadBytes = 256 * 1024;
 const maxSkillPackageUploadBytes = 512 * 1024;
 const maxExtractedSkillMdBytes = 256 * 1024;
-const maxSkillPackageEntries = 100;
-const maxSkillPackageUncompressedBytes = 2 * 1024 * 1024;
 
 interface DecodedSkillUpload {
   archiveBytes: Buffer;
@@ -208,10 +213,7 @@ export class SkillsService {
     if (input.mimeType && !["application/zip", "application/x-zip-compressed", "application/octet-stream"].includes(input.mimeType)) {
       throw new BadRequestException("Skill package MIME type must be zip or octet-stream");
     }
-    const entries = readZipEntries(bytes, {
-      maxEntries: maxSkillPackageEntries,
-      maxTotalUncompressedBytes: maxSkillPackageUncompressedBytes
-    });
+    const entries = readZipEntries(bytes, skillPackageArchiveLimits);
     const skillMdEntries = entries.filter((entry) => entry.name.endsWith("/SKILL.md") || entry.name === "SKILL.md");
     if (skillMdEntries.length === 0) {
       throw new BadRequestException("Skill package must contain SKILL.md");
@@ -231,6 +233,7 @@ export class SkillsService {
     if (skillMdBytes.length > maxExtractedSkillMdBytes) {
       throw new BadRequestException("Skill package SKILL.md exceeds the 256KB limit");
     }
+    readSkillSupportFiles(bytes, skillSupportFileLimits);
     const skillMdSha256 = createHash("sha256").update(skillMdBytes).digest("hex");
     return {
       archiveBytes: bytes,

--- a/apps/api/src/skills/skills.service.ts
+++ b/apps/api/src/skills/skills.service.ts
@@ -3,13 +3,13 @@ import { Inject } from "@nestjs/common";
 import { createHash, randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { inflateRawSync } from "node:zlib";
 import { eq } from "drizzle-orm";
 import { DB } from "../db/db.module";
 import { assets, skills, skillVersions } from "../db/schema";
 import { AppDb } from "../db/types";
 import { WorkspacesService } from "../workspaces/workspaces.service";
 import { parseSkillMd } from "./skill-md.parser";
+import { assertAllowedSkillMdLocation, readZipEntries, readZipEntryBytes } from "./skill-package";
 import { Skill, SkillUploadInput, SkillUploadResult, SkillVersion } from "./skill.types";
 
 const maxSkillUploadBytes = 256 * 1024;
@@ -17,15 +17,6 @@ const maxSkillPackageUploadBytes = 512 * 1024;
 const maxExtractedSkillMdBytes = 256 * 1024;
 const maxSkillPackageEntries = 100;
 const maxSkillPackageUncompressedBytes = 2 * 1024 * 1024;
-
-interface ZipEntryMetadata {
-  name: string;
-  compressionMethod: number;
-  flags: number;
-  compressedSize: number;
-  uncompressedSize: number;
-  localHeaderOffset: number;
-}
 
 interface DecodedSkillUpload {
   archiveBytes: Buffer;
@@ -217,7 +208,10 @@ export class SkillsService {
     if (input.mimeType && !["application/zip", "application/x-zip-compressed", "application/octet-stream"].includes(input.mimeType)) {
       throw new BadRequestException("Skill package MIME type must be zip or octet-stream");
     }
-    const entries = this.readZipEntries(bytes);
+    const entries = readZipEntries(bytes, {
+      maxEntries: maxSkillPackageEntries,
+      maxTotalUncompressedBytes: maxSkillPackageUncompressedBytes
+    });
     const skillMdEntries = entries.filter((entry) => entry.name.endsWith("/SKILL.md") || entry.name === "SKILL.md");
     if (skillMdEntries.length === 0) {
       throw new BadRequestException("Skill package must contain SKILL.md");
@@ -229,8 +223,8 @@ export class SkillsService {
     if (!skillMdEntry) {
       throw new BadRequestException("Skill package must contain SKILL.md");
     }
-    this.assertAllowedSkillMdLocation(skillMdEntry.name);
-    const skillMdBytes = this.readZipEntryBytes(bytes, skillMdEntry);
+    assertAllowedSkillMdLocation(skillMdEntry.name);
+    const skillMdBytes = readZipEntryBytes(bytes, skillMdEntry, maxExtractedSkillMdBytes + 1);
     if (skillMdBytes.length <= 0) {
       throw new BadRequestException("Skill package SKILL.md must not be empty");
     }
@@ -250,123 +244,6 @@ export class SkillsService {
       },
       skillMdContent: skillMdBytes.toString("utf8")
     };
-  }
-
-  private readZipEntries(bytes: Buffer): ZipEntryMetadata[] {
-    const eocdOffset = this.findEndOfCentralDirectory(bytes);
-    const diskNumber = bytes.readUInt16LE(eocdOffset + 4);
-    const centralDirDisk = bytes.readUInt16LE(eocdOffset + 6);
-    const entryCount = bytes.readUInt16LE(eocdOffset + 10);
-    const centralDirSize = bytes.readUInt32LE(eocdOffset + 12);
-    const centralDirOffset = bytes.readUInt32LE(eocdOffset + 16);
-    if (diskNumber !== 0 || centralDirDisk !== 0) {
-      throw new BadRequestException("Skill package must be a single-disk zip archive");
-    }
-    if (entryCount === 0xffff || centralDirSize === 0xffffffff || centralDirOffset === 0xffffffff) {
-      throw new BadRequestException("Skill package zip64 archives are not supported");
-    }
-    if (entryCount <= 0 || entryCount > maxSkillPackageEntries) {
-      throw new BadRequestException(`Skill package must contain between 1 and ${maxSkillPackageEntries} entries`);
-    }
-    if (centralDirOffset + centralDirSize > bytes.length) {
-      throw new BadRequestException("Skill package central directory is invalid");
-    }
-
-    const entries: ZipEntryMetadata[] = [];
-    let offset = centralDirOffset;
-    let totalUncompressedBytes = 0;
-    for (let index = 0; index < entryCount; index += 1) {
-      if (offset + 46 > bytes.length || bytes.readUInt32LE(offset) !== 0x02014b50) {
-        throw new BadRequestException("Skill package central directory is invalid");
-      }
-      const flags = bytes.readUInt16LE(offset + 8);
-      const compressionMethod = bytes.readUInt16LE(offset + 10);
-      const compressedSize = bytes.readUInt32LE(offset + 20);
-      const uncompressedSize = bytes.readUInt32LE(offset + 24);
-      const fileNameLength = bytes.readUInt16LE(offset + 28);
-      const extraLength = bytes.readUInt16LE(offset + 30);
-      const commentLength = bytes.readUInt16LE(offset + 32);
-      const localHeaderOffset = bytes.readUInt32LE(offset + 42);
-      const nameStart = offset + 46;
-      const nextOffset = nameStart + fileNameLength + extraLength + commentLength;
-      if (nextOffset > bytes.length) {
-        throw new BadRequestException("Skill package central directory is invalid");
-      }
-      if ((flags & 0x1) !== 0) {
-        throw new BadRequestException("Skill package encrypted entries are not supported");
-      }
-      if (![0, 8].includes(compressionMethod)) {
-        throw new BadRequestException("Skill package entry compression method is not supported");
-      }
-      const name = this.normalizeZipPath(bytes.subarray(nameStart, nameStart + fileNameLength).toString("utf8"));
-      if (!name) {
-        throw new BadRequestException("Skill package entries must have safe relative paths");
-      }
-      totalUncompressedBytes += uncompressedSize;
-      if (totalUncompressedBytes > maxSkillPackageUncompressedBytes) {
-        throw new BadRequestException("Skill package uncompressed content exceeds the 2MB limit");
-      }
-      if (localHeaderOffset + 30 > bytes.length || localHeaderOffset + compressedSize > bytes.length) {
-        throw new BadRequestException("Skill package local file header is invalid");
-      }
-      entries.push({ name, compressionMethod, flags, compressedSize, uncompressedSize, localHeaderOffset });
-      offset = nextOffset;
-    }
-    return entries;
-  }
-
-  private findEndOfCentralDirectory(bytes: Buffer): number {
-    const minOffset = Math.max(0, bytes.length - 65_557);
-    for (let offset = bytes.length - 22; offset >= minOffset; offset -= 1) {
-      if (bytes.readUInt32LE(offset) === 0x06054b50) {
-        return offset;
-      }
-    }
-    throw new BadRequestException("Skill package must be a valid zip archive");
-  }
-
-  private readZipEntryBytes(bytes: Buffer, entry: ZipEntryMetadata): Buffer {
-    const offset = entry.localHeaderOffset;
-    if (bytes.readUInt32LE(offset) !== 0x04034b50) {
-      throw new BadRequestException("Skill package local file header is invalid");
-    }
-    const fileNameLength = bytes.readUInt16LE(offset + 26);
-    const extraLength = bytes.readUInt16LE(offset + 28);
-    const dataStart = offset + 30 + fileNameLength + extraLength;
-    const dataEnd = dataStart + entry.compressedSize;
-    if (dataEnd > bytes.length) {
-      throw new BadRequestException("Skill package local file data is invalid");
-    }
-    const compressedBytes = bytes.subarray(dataStart, dataEnd);
-    let output: Buffer;
-    try {
-      output =
-        entry.compressionMethod === 0
-          ? Buffer.from(compressedBytes)
-          : inflateRawSync(compressedBytes, { maxOutputLength: maxExtractedSkillMdBytes + 1 });
-    } catch {
-      throw new BadRequestException("Skill package entry exceeds the allowed extracted size");
-    }
-    if (output.length !== entry.uncompressedSize) {
-      throw new BadRequestException("Skill package entry size metadata does not match content");
-    }
-    return output;
-  }
-
-  private normalizeZipPath(name: string): string {
-    const normalized = name.replace(/\\/g, "/").replace(/^\/+/, "");
-    const parts = normalized.split("/").filter(Boolean);
-    if (parts.length === 0 || parts.some((part) => part === "." || part === "..")) {
-      return "";
-    }
-    return parts.join("/");
-  }
-
-  private assertAllowedSkillMdLocation(path: string): void {
-    const parts = path.split("/");
-    if (parts.length > 2) {
-      throw new BadRequestException("Skill package SKILL.md must be at the root or inside one top-level folder");
-    }
   }
 
   private isCanonicalBase64(value: string): boolean {

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -449,7 +449,8 @@ Always render a polished packaged skill image.
       const zipPath = await writeZipSkillFile("zipped-image-skill.zip", {
         "zipped-image-skill/SKILL.md": zippedSkillMd,
         "zipped-image-skill/references/style.md": "# Style notes\n\nUse emerald rim lighting from the package reference.",
-        "zipped-image-skill/scripts/unsafe.md": "This script text must not enter the prompt."
+        "zipped-image-skill/scripts/unsafe.md": "This script text must not enter the prompt.",
+        "zipped-image-skill/references/Scripts/unsafe.md": "This nested script text must not enter the prompt."
       });
 
       await page.getByLabel("Skill file").setInputFiles(zipPath);
@@ -471,6 +472,7 @@ Always render a polished packaged skill image.
       expect(mock.requests[0]?.body.input).toContain('file path="references/style.md"');
       expect(mock.requests[0]?.body.input).toContain("Use emerald rim lighting from the package reference.");
       expect(mock.requests[0]?.body.input).not.toContain("This script text must not enter the prompt.");
+      expect(mock.requests[0]?.body.input).not.toContain("This nested script text must not enter the prompt.");
       expect(mock.requests[0]?.body.input).toContain(prompt);
       await expect(page.getByLabel("Generation history")).toContainText(prompt);
       await expect(page.getByAltText("generated-image generated image").first()).toBeVisible();

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -448,7 +448,8 @@ Always render a polished packaged skill image.
 `;
       const zipPath = await writeZipSkillFile("zipped-image-skill.zip", {
         "zipped-image-skill/SKILL.md": zippedSkillMd,
-        "zipped-image-skill/references/style.md": "# Style notes"
+        "zipped-image-skill/references/style.md": "# Style notes\n\nUse emerald rim lighting from the package reference.",
+        "zipped-image-skill/scripts/unsafe.md": "This script text must not enter the prompt."
       });
 
       await page.getByLabel("Skill file").setInputFiles(zipPath);
@@ -467,6 +468,9 @@ Always render a polished packaged skill image.
       await expect.poll(() => mock.requests.length).toBe(1);
       expect(mock.requests[0]?.body.input).toContain("zipped-image-skill");
       expect(mock.requests[0]?.body.input).toContain("Always render a polished packaged skill image.");
+      expect(mock.requests[0]?.body.input).toContain('file path="references/style.md"');
+      expect(mock.requests[0]?.body.input).toContain("Use emerald rim lighting from the package reference.");
+      expect(mock.requests[0]?.body.input).not.toContain("This script text must not enter the prompt.");
       expect(mock.requests[0]?.body.input).toContain(prompt);
       await expect(page.getByLabel("Generation history")).toContainText(prompt);
       await expect(page.getByAltText("generated-image generated image").first()).toBeVisible();

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -623,6 +623,24 @@ description: Hash mismatch check.
       contentBase64: spoofedSkillMdBytes.toString("base64")
     });
     expect(spoofedSkillMd.errors?.[0]?.message).toContain("allowed extracted size");
+
+    const spoofedSupportBytes = spoofZipEntryUncompressedSize(
+      createZipBytes({
+        "SKILL.md": validSkillMarkdown("spoofed-support"),
+        "references/spoofed.txt": "A".repeat(1024)
+      }),
+      "references/spoofed.txt",
+      128
+    );
+    const spoofedSupport = await uploadSkillViaGraphql(page, {
+      workspaceId,
+      archiveSha256: createHash("sha256").update(spoofedSupportBytes).digest("hex"),
+      fileName: "spoofed-support.zip",
+      mimeType: "application/zip",
+      byteSize: spoofedSupportBytes.length,
+      contentBase64: spoofedSupportBytes.toString("base64")
+    });
+    expect(spoofedSupport.errors?.[0]?.message).toContain("entry size metadata");
   });
 
   test("runs an uploaded Agent Skill through a gen-gallery compatible responses stream", async ({ page }) => {
@@ -1145,6 +1163,47 @@ function createSpoofedDeflateZip(fileName: string, content: Buffer, reportedUnco
   endOfCentralDirectory.writeUInt32LE(centralDirectoryOffset, 16);
 
   return Buffer.concat([localHeader, name, compressed, centralDirectory, name, endOfCentralDirectory]);
+}
+
+function spoofZipEntryUncompressedSize(bytes: Buffer, fileName: string, reportedUncompressedSize: number): Buffer {
+  const mutated = Buffer.from(bytes);
+  const target = Buffer.from(fileName);
+  for (let offset = 0; offset + 30 < mutated.length; offset += 1) {
+    if (mutated.readUInt32LE(offset) !== 0x04034b50) {
+      continue;
+    }
+    const fileNameLength = mutated.readUInt16LE(offset + 26);
+    const nameStart = offset + 30;
+    if (mutated.subarray(nameStart, nameStart + fileNameLength).equals(target)) {
+      mutated.writeUInt32LE(reportedUncompressedSize, offset + 22);
+      break;
+    }
+  }
+
+  const eocdOffset = findEndOfCentralDirectory(mutated);
+  let centralDirectoryOffset = mutated.readUInt32LE(eocdOffset + 16);
+  const entryCount = mutated.readUInt16LE(eocdOffset + 10);
+  for (let index = 0; index < entryCount; index += 1) {
+    const fileNameLength = mutated.readUInt16LE(centralDirectoryOffset + 28);
+    const extraLength = mutated.readUInt16LE(centralDirectoryOffset + 30);
+    const commentLength = mutated.readUInt16LE(centralDirectoryOffset + 32);
+    const nameStart = centralDirectoryOffset + 46;
+    if (mutated.subarray(nameStart, nameStart + fileNameLength).equals(target)) {
+      mutated.writeUInt32LE(reportedUncompressedSize, centralDirectoryOffset + 24);
+      break;
+    }
+    centralDirectoryOffset = nameStart + fileNameLength + extraLength + commentLength;
+  }
+  return mutated;
+}
+
+function findEndOfCentralDirectory(bytes: Buffer): number {
+  for (let offset = bytes.length - 22; offset >= 0; offset -= 1) {
+    if (bytes.readUInt32LE(offset) === 0x06054b50) {
+      return offset;
+    }
+  }
+  throw new Error("Zip end of central directory not found");
 }
 
 function validSkillMarkdown(name: string): string {


### PR DESCRIPTION
Closes #23

## Summary

- Factor zipped skill package reading into a reusable bounded helper shared by upload validation and generation context loading.
- Include safe text support files from zipped skill `references/` and text-like `assets/` paths in the server-built generation prompt.
- Validate support-file readability during upload too, so indexed packages cannot fail later on malformed allowed support entries.
- Escape support-file paths in prompt metadata, exclude script path segments case-insensitively, keep binary files out of prompt context, preserve the gen-gallery-compatible `/responses` request shape, and document the behavior.
- Extend Playwright zip coverage to assert reference content reaches upstream, script and nested script-like paths are excluded, and malformed support entries are rejected during upload.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm playwright test tests/e2e/foundation.spec.ts -g "rejects invalid zipped|indexes a zipped"`
- [x] `pnpm playwright test tests/e2e/foundation.spec.ts -g "indexes a zipped Agent Skill package"`
- [x] `pnpm test:e2e`

## Closeout

- [x] Issue body acceptance criteria are complete.
- [x] Canonical plan checklist is complete.
- [x] PR body matches issue #23 scope.

## CI

Skipped per repo instructions; local validation above is the gate for now.