### PR TITLE
Make API dev script emit decorator metadata

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "commonjs",
   "scripts": {
-    "dev": "tsx watch src/main.ts",
+    "dev": "tsc -p tsconfig.build.json && node dist/main.js",
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
Closes #25

## Summary

- Change the API dev script from `tsx watch src/main.ts` to a TypeScript-compiled Node path so Nest GraphQL receives emitted decorator metadata.
- Preserve the existing production/e2e `build` and `start` paths.
- Verify both API-only dev startup and root `pnpm dev` startup with live HTTP probes.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --filter @gen-image-studio/api dev` served `http://localhost:4000/graphql`
- [x] `pnpm dev` served `http://localhost:5173` and `http://localhost:4000/graphql`

## Closeout

- [x] Issue body acceptance criteria are complete.
- [x] Canonical plan checklist is complete.
- [x] PR body matches issue #25 scope.

## CI

Skipped per repo instructions; local validation above is the gate for now.