### PR TITLE
Load root .env for API package dev process

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -13,7 +13,10 @@ import { WorkspacesModule } from "./workspaces/workspaces.module";
 
 @Module({
   imports: [
-    ConfigModule.forRoot({ isGlobal: true }),
+    ConfigModule.forRoot({
+      isGlobal: true,
+      envFilePath: [".env", "apps/api/.env", "../../.env"]
+    }),
     GraphQLModule.forRoot<ApolloDriverConfig>({
       driver: ApolloDriver,
       autoSchemaFile: true,


### PR DESCRIPTION
## Summary

- Implements the scope captured in #27: Load root .env for API package dev process.
- Configures Nest ConfigModule to search package-local and repo-root `.env` files for local API dev.
- Preserves the existing password-login gate; no secrets are committed.

## Linked Issue

Closes #27

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gen-image-studio/issues/27#issuecomment-4352364892

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] GraphQL `loginWithPassword` probe succeeds for `tester1@example.test` with root `.env`
- [x] Root `pnpm dev` web/API probes succeed