### PR TITLE
Document local password login and current generation flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,8 @@ SESSION_SECRET=replace-with-local-session-secret
 PROVIDER_SECRET_KEY=replace-with-32-byte-base64-secret
 ASSET_STORAGE_DIR=.data/assets
 
+# Local/e2e only. Disable outside local development and automated tests.
+ENABLE_E2E_PASSWORD_LOGIN=true
+# Optional override. When omitted, the app provides tester1..tester5@example.test
+# with passwords test-password-1..test-password-5.
+# E2E_TEST_ACCOUNTS_JSON=[{"id":"00000000-0000-4000-8000-000000000001","email":"tester1@example.test","password":"test-password-1","displayName":"Tester 1"}]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Gen Image Studio is a workspace-based image generation app where users bring the
 
 - pnpm monorepo
 - Vite + React + Apollo Client + Base UI in `apps/web`
-- NestJS + GraphQL + Drizzle + PostgreSQL + Vercel AI SDK in `apps/api`
+- NestJS + GraphQL + Drizzle + PostgreSQL in `apps/api`
+- Vercel AI SDK provider wiring for user-configured language models, plus a direct gen-gallery-compatible Responses image transport
 - Shared frontend/backend contracts in `packages/shared`
 
 ## Local Setup
@@ -14,12 +15,30 @@ Gen Image Studio is a workspace-based image generation app where users bring the
 ```bash
 pnpm install
 cp .env.example .env
-docker compose up -d postgres
-pnpm db:generate
+docker compose up -d --wait postgres
+pnpm db:migrate
 pnpm dev
 ```
 
 The app does not use global model provider environment variables such as `OPENAI_API_KEY`. Users configure provider base URLs, API keys, models, and capabilities in the app. The API stores those secrets server-side and only returns redacted status to the frontend.
+
+## Local Test Login
+
+`.env.example` enables local/e2e password login for repeatable browser validation. It is gated by:
+
+```bash
+ENABLE_E2E_PASSWORD_LOGIN=true
+```
+
+With no `E2E_TEST_ACCOUNTS_JSON` override, the API creates five local accounts on demand:
+
+- `tester1@example.test` / `test-password-1`
+- `tester2@example.test` / `test-password-2`
+- `tester3@example.test` / `test-password-3`
+- `tester4@example.test` / `test-password-4`
+- `tester5@example.test` / `test-password-5`
+
+Set `ENABLE_E2E_PASSWORD_LOGIN=false` outside local development and automated tests.
 
 ## Passkeys
 
@@ -45,8 +64,11 @@ Initial roles:
 
 ## Agent Skills
 
-Uploaded skills follow the AI SDK Agent Skills directory model. Each package must include a `SKILL.md` file with frontmatter metadata. The backend indexes metadata and stores the original package/extracted directory reference, but this foundation slice does not execute uploaded code.
-For zipped packages, generation also includes bounded text files from safe support paths such as `references/` and text-like `assets/`; scripts and binary files are not executed or added to prompts.
+Uploaded skills follow the AI SDK Agent Skills directory model. Each package must include a `SKILL.md` file with frontmatter metadata. The backend indexes metadata, stores the original package and extracted instruction asset, and uses those instructions when running image generation jobs.
+
+Image generation requests use the direct gen-gallery-compatible Responses request shape against each workspace provider profile: the API posts to the user-configured provider base URL with that provider's stored API key, text model, image tool model, and image-generation tool capability. It does not read global provider keys from process environment.
+
+For zipped packages, generation also includes bounded text files from safe support paths such as `references/` and text-like `assets/`. Package scripts and binary files are not executed or added to prompts.
 
 ## Validation
 
@@ -54,6 +76,7 @@ For zipped packages, generation also includes bounded text files from safe suppo
 pnpm typecheck
 pnpm test
 pnpm build
+pnpm test:e2e
 ```
 
 CI is intentionally skipped for now.


### PR DESCRIPTION
## Summary

- Implements the scope captured in #29: Document local password login and current generation flow.
- Adds local/e2e password login guidance and default tester account details to `.env.example` and README.
- Refreshes README setup and Agent Skills generation wording to match the current direct gen-gallery-compatible Responses transport.

## Linked Issue

Closes #29

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gen-image-studio/issues/29#issuecomment-4352502220

## Validation

- [x] `pnpm typecheck` via `rtk proxy pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm test:e2e` (25 passed)