### PR TITLE
Route workspace sections into separate studio pages

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,8 @@
     "graphql": "^16.10.0",
     "lucide-react": "^0.468.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.14.2"
   },
   "devDependencies": {
     "@types/react": "^19.0.2",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { Button } from "@base-ui/react/button";
 import { startAuthentication, startRegistration } from "@simplewebauthn/browser";
 import { Boxes, KeyRound, Settings, Upload, UsersRound } from "lucide-react";
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { Navigate, NavLink, Route, Routes, useLocation } from "react-router-dom";
 import {
   ADD_WORKSPACE_MEMBER,
   CURRENT_USER_QUERY,
@@ -75,8 +76,6 @@ interface GenerationJob {
 }
 
 type WorkspaceRole = "owner" | "admin" | "member" | "viewer";
-type WorkspacePanel = "studio" | "skills" | "providers" | "members" | "settings";
-
 interface DashboardData {
   currentUser: {
     id: string;
@@ -125,11 +124,7 @@ interface LoggedInUser {
 
 export function App() {
   const apollo = useApolloClient();
-  const topbarRef = useRef<HTMLElement | null>(null);
-  const providerPanelRef = useRef<HTMLElement | null>(null);
-  const skillPanelRef = useRef<HTMLElement | null>(null);
-  const generationPanelRef = useRef<HTMLElement | null>(null);
-  const memberPanelRef = useRef<HTMLElement | null>(null);
+  const location = useLocation();
   const providerNameInputRef = useRef<HTMLInputElement | null>(null);
   const [email, setEmail] = useState("tester1@example.test");
   const [password, setPassword] = useState("test-password-1");
@@ -146,7 +141,6 @@ export function App() {
   const [generationProviderId, setGenerationProviderId] = useState("");
   const [generationSkillId, setGenerationSkillId] = useState("");
   const [generationPrompt, setGenerationPrompt] = useState("Create a clean studio image using this skill.");
-  const [activePanel, setActivePanel] = useState<WorkspacePanel>("studio");
   const [loginMessage, setLoginMessage] = useState<string | null>(null);
   const [passkeyMessage, setPasskeyMessage] = useState<string | null>(null);
   const currentUserQuery = useQuery<DashboardData>(CURRENT_USER_QUERY, {
@@ -322,30 +316,9 @@ export function App() {
     setProviderApiKey("test-key");
     if (options.focusForm) {
       window.requestAnimationFrame(() => {
-        scrollToPanel("providers", { focusPanel: false });
         providerNameInputRef.current?.focus();
       });
     }
-  }
-
-  function scrollToPanel(panel: WorkspacePanel, options: { focusPanel?: boolean } = {}) {
-    const panelRefs: Record<WorkspacePanel, HTMLElement | null> = {
-      studio: generationPanelRef.current,
-      skills: skillPanelRef.current,
-      providers: providerPanelRef.current,
-      members: memberPanelRef.current,
-      settings: topbarRef.current
-    };
-    const target = panelRefs[panel];
-    setActivePanel(panel);
-    target?.scrollIntoView({ block: "start" });
-    if (options.focusPanel ?? true) {
-      target?.focus({ preventScroll: true });
-    }
-  }
-
-  function navItemClass(panel: WorkspacePanel) {
-    return activePanel === panel ? "nav-item active" : "nav-item";
   }
 
   async function handleDeleteProvider() {
@@ -472,6 +445,10 @@ export function App() {
     );
   }
 
+  if (location.pathname === "/") {
+    return <Navigate to="/studio" replace />;
+  }
+
   return (
     <main className="app-shell">
       <aside className="sidebar">
@@ -484,31 +461,31 @@ export function App() {
         </div>
 
         <nav className="nav-list" aria-label="Primary">
-          <Button className={navItemClass("studio")} aria-current={activePanel === "studio" ? "location" : undefined} onClick={() => scrollToPanel("studio")}>
+          <NavLink className={navItemClass} to="/studio">
             <Boxes size={18} />
             Studio
-          </Button>
-          <Button className={navItemClass("skills")} aria-current={activePanel === "skills" ? "location" : undefined} onClick={() => scrollToPanel("skills")}>
+          </NavLink>
+          <NavLink className={navItemClass} to="/skills">
             <Upload size={18} />
             Skills
-          </Button>
-          <Button className={navItemClass("providers")} aria-current={activePanel === "providers" ? "location" : undefined} onClick={() => scrollToPanel("providers")}>
+          </NavLink>
+          <NavLink className={navItemClass} to="/providers">
             <KeyRound size={18} />
             Providers
-          </Button>
-          <Button className={navItemClass("members")} aria-current={activePanel === "members" ? "location" : undefined} onClick={() => scrollToPanel("members")}>
+          </NavLink>
+          <NavLink className={navItemClass} to="/members">
             <UsersRound size={18} />
             Members
-          </Button>
-          <Button className={navItemClass("settings")} aria-current={activePanel === "settings" ? "location" : undefined} onClick={() => scrollToPanel("settings")}>
+          </NavLink>
+          <NavLink className={navItemClass} to="/settings">
             <Settings size={18} />
             Settings
-          </Button>
+          </NavLink>
         </nav>
       </aside>
 
       <section className="workspace">
-        <header className="topbar" id="settings-panel" ref={topbarRef} tabIndex={-1} aria-labelledby="workspace-title">
+        <header className="topbar" aria-labelledby="workspace-title">
           <div>
             <p className="eyebrow">{currentUserName}</p>
             <h1 id="workspace-title">{activeWorkspace?.name ?? "Workspace setup"}</h1>
@@ -528,19 +505,101 @@ export function App() {
             ) : null}
           </div>
           <div className="topbar-actions">
-            <Button className="secondary-button" onClick={handleRegisterPasskey}>
-              <KeyRound size={18} />
-              Register Passkey
-            </Button>
             <Button className="secondary-button" onClick={handleLogout}>
               Sign out
             </Button>
           </div>
-          {passkeyMessage ? <p className="success-text topbar-message">{passkeyMessage}</p> : null}
         </header>
 
-        <div className="content-grid">
-          <section className="panel wide" id="providers-panel" ref={providerPanelRef} tabIndex={-1} aria-labelledby="providers-title">
+        <div className="content-grid route-content">
+          <Routes>
+            <Route
+              path="/studio"
+              element={
+                <section className="panel" aria-labelledby="studio-title">
+                  <div className="panel-header compact">
+                    <div>
+                      <h2 id="studio-title">Generate Image</h2>
+                      <p>Run the selected Agent Skill against a workspace provider.</p>
+                    </div>
+                  </div>
+                  <form className="stacked-form" onSubmit={handleGenerationSubmit}>
+                    <label>
+                      Generation provider
+                      <select
+                        value={selectedProviderId}
+                        onChange={(event) => setGenerationProviderId(event.target.value)}
+                      >
+                        <option value="">Select provider</option>
+                        {providerRows.map((profile) => (
+                          <option key={profile.id} value={profile.id}>
+                            {profile.displayName}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <label>
+                      Generation skill
+                      <select value={selectedSkillId} onChange={(event) => setGenerationSkillId(event.target.value)}>
+                        <option value="">Select skill</option>
+                        {skillRows.map((skill) => (
+                          <option key={skill.id} value={skill.id}>
+                            {skill.name}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <label>
+                      Image prompt
+                      <textarea value={generationPrompt} onChange={(event) => setGenerationPrompt(event.target.value)} rows={4} />
+                    </label>
+                    {generationError ? <p className="error-text">{generationError}</p> : null}
+                    <Button className="primary-button" type="submit" disabled={!selectedProviderId || !selectedSkillId || generationMutation.loading}>
+                      {generationMutation.loading ? "Running" : "Run Generation"}
+                    </Button>
+                  </form>
+                  <div className="job-history" aria-label="Generation history">
+                    {jobRows.length === 0 ? (
+                      <div className="empty-block">No generation jobs in this workspace.</div>
+                    ) : (
+                      jobRows.map((job) => {
+                        const latestEvent = job.events.at(-1);
+                        return (
+                          <article className="job-result" key={job.id}>
+                            <strong>Job {job.status}</strong>
+                            <span>{job.prompt}</span>
+                            {latestEvent?.message ? <span>{latestEvent.message}</span> : null}
+                            {job.outputs.map((output) => (
+                              <div className="job-output" key={output.id}>
+                                {output.mimeType.startsWith("image/") ? (
+                                  <img
+                                    alt={`${output.label} generated image`}
+                                    className="job-output-image"
+                                    src={resolveApiUrl(output.assetUrl)}
+                                  />
+                                ) : null}
+                                <div className="job-output-meta">
+                                  <span>
+                                    {output.label} - {output.mimeType} - {output.byteSize} bytes
+                                  </span>
+                                  <a href={resolveApiUrl(output.assetUrl)} target="_blank" rel="noreferrer">
+                                    Open image
+                                  </a>
+                                </div>
+                              </div>
+                            ))}
+                          </article>
+                        );
+                      })
+                    )}
+                  </div>
+                </section>
+              }
+            />
+            <Route
+              path="/providers"
+              element={
+                <section className="panel" aria-labelledby="providers-title">
             <div className="panel-header">
               <div>
                 <h2 id="providers-title">Provider Profiles</h2>
@@ -616,8 +675,12 @@ export function App() {
               </div>
             </form>
           </section>
-
-          <section className="panel" id="skills-panel" ref={skillPanelRef} tabIndex={-1} aria-labelledby="skills-title">
+              }
+            />
+            <Route
+              path="/skills"
+              element={
+                <section className="panel" aria-labelledby="skills-title">
             <div className="panel-header compact">
               <div>
                 <h2 id="skills-title">Agent Skills</h2>
@@ -656,87 +719,12 @@ export function App() {
               </Button>
             </form>
           </section>
-
-          <section className="panel" id="studio-panel" ref={generationPanelRef} tabIndex={-1} aria-labelledby="studio-title">
-            <div className="panel-header compact">
-              <div>
-                <h2 id="studio-title">Generate Image</h2>
-                <p>Run the selected Agent Skill against a workspace provider.</p>
-              </div>
-            </div>
-            <form className="stacked-form" onSubmit={handleGenerationSubmit}>
-              <label>
-                Generation provider
-                <select
-                  value={selectedProviderId}
-                  onChange={(event) => setGenerationProviderId(event.target.value)}
-                >
-                  <option value="">Select provider</option>
-                  {providerRows.map((profile) => (
-                    <option key={profile.id} value={profile.id}>
-                      {profile.displayName}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                Generation skill
-                <select value={selectedSkillId} onChange={(event) => setGenerationSkillId(event.target.value)}>
-                  <option value="">Select skill</option>
-                  {skillRows.map((skill) => (
-                    <option key={skill.id} value={skill.id}>
-                      {skill.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                Image prompt
-                <textarea value={generationPrompt} onChange={(event) => setGenerationPrompt(event.target.value)} rows={4} />
-              </label>
-              {generationError ? <p className="error-text">{generationError}</p> : null}
-              <Button className="primary-button" type="submit" disabled={!selectedProviderId || !selectedSkillId || generationMutation.loading}>
-                {generationMutation.loading ? "Running" : "Run Generation"}
-              </Button>
-            </form>
-            <div className="job-history" aria-label="Generation history">
-              {jobRows.length === 0 ? (
-                <div className="empty-block">No generation jobs in this workspace.</div>
-              ) : (
-                jobRows.map((job) => {
-                  const latestEvent = job.events.at(-1);
-                  return (
-                    <article className="job-result" key={job.id}>
-                      <strong>Job {job.status}</strong>
-                      <span>{job.prompt}</span>
-                      {latestEvent?.message ? <span>{latestEvent.message}</span> : null}
-                      {job.outputs.map((output) => (
-                        <div className="job-output" key={output.id}>
-                          {output.mimeType.startsWith("image/") ? (
-                            <img
-                              alt={`${output.label} generated image`}
-                              className="job-output-image"
-                              src={resolveApiUrl(output.assetUrl)}
-                            />
-                          ) : null}
-                          <div className="job-output-meta">
-                            <span>
-                              {output.label} - {output.mimeType} - {output.byteSize} bytes
-                            </span>
-                            <a href={resolveApiUrl(output.assetUrl)} target="_blank" rel="noreferrer">
-                              Open image
-                            </a>
-                          </div>
-                        </div>
-                      ))}
-                    </article>
-                  );
-                })
-              )}
-            </div>
-          </section>
-
-          <section className="panel" id="members-panel" ref={memberPanelRef} tabIndex={-1} aria-labelledby="members-title">
+              }
+            />
+            <Route
+              path="/members"
+              element={
+                <section className="panel" aria-labelledby="members-title">
             <div className="panel-header compact">
               <div>
                 <h2 id="members-title">Workspace Access</h2>
@@ -789,6 +777,40 @@ export function App() {
               </Button>
             </form>
           </section>
+              }
+            />
+            <Route
+              path="/settings"
+              element={
+                <section className="panel" aria-labelledby="settings-title">
+                  <div className="panel-header compact">
+                    <div>
+                      <h2 id="settings-title">Settings</h2>
+                      <p>Account security and workspace context for this browser session.</p>
+                    </div>
+                  </div>
+                  <div className="settings-list">
+                    <div>
+                      <span>Signed in as</span>
+                      <strong>{currentUserName}</strong>
+                    </div>
+                    <div>
+                      <span>Active workspace</span>
+                      <strong>{activeWorkspace?.name ?? "Workspace setup"}</strong>
+                    </div>
+                  </div>
+                  <div className="form-actions settings-actions">
+                    <Button className="secondary-button" onClick={handleRegisterPasskey}>
+                      <KeyRound size={18} />
+                      Register Passkey
+                    </Button>
+                  </div>
+                  {passkeyMessage ? <p className="success-text">{passkeyMessage}</p> : null}
+                </section>
+              }
+            />
+            <Route path="*" element={<Navigate to="/studio" replace />} />
+          </Routes>
         </div>
       </section>
     </main>
@@ -815,4 +837,8 @@ function resolveApiUrl(path: string): string {
 
 function fallbackSkillMimeType(fileName: string): string {
   return fileName.toLowerCase().endsWith(".zip") ? "application/octet-stream" : "text/markdown";
+}
+
+function navItemClass({ isActive }: { isActive: boolean }) {
+  return isActive ? "nav-item active" : "nav-item";
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,7 @@
 import { ApolloClient, ApolloProvider, HttpLink, InMemoryCache } from "@apollo/client";
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import { App } from "./App";
 import "./styles.css";
 
@@ -17,7 +18,9 @@ const client = new ApolloClient({
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ApolloProvider client={client}>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -132,6 +132,7 @@ button {
   padding: 10px 12px;
   color: #e7efea;
   background: transparent;
+  text-decoration: none;
 }
 
 .nav-item.active,
@@ -214,6 +215,10 @@ button {
   gap: 16px;
 }
 
+.route-content {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .panel {
   background: white;
   border: 1px solid #dfe6e1;
@@ -283,6 +288,7 @@ button {
 .skill-list,
 .member-list,
 .metric-list,
+.settings-list,
 .job-history,
 .job-result {
   display: grid;
@@ -326,6 +332,7 @@ button {
 .skill-item,
 .member-item,
 .metric-list > div,
+.settings-list > div,
 .job-result {
   border: 1px solid #e2e9e5;
   border-radius: 8px;
@@ -382,13 +389,24 @@ button {
 .skill-item span,
 .member-item strong,
 .member-item span,
+.settings-list strong,
+.settings-list span,
 .metric-list span,
 .metric-list strong {
   display: block;
 }
 
+.settings-list span {
+  color: #72807a;
+  font-size: 0.86rem;
+}
+
 .metric-list strong {
   margin-top: 4px;
+}
+
+.settings-actions {
+  margin-top: 16px;
 }
 
 @media (max-width: 900px) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.5(react@19.2.5)
+      react-router-dom:
+        specifier: ^7.14.2
+        version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
       '@types/react':
         specifier: ^19.0.2
@@ -1841,6 +1844,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
@@ -2589,6 +2596,23 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@7.14.2:
+    resolution: {integrity: sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.14.2:
+    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
@@ -2668,6 +2692,9 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -4522,6 +4549,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.1.1: {}
+
   cors@2.8.5:
     dependencies:
       object-assign: 4.1.1
@@ -5236,6 +5265,20 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-router-dom@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.5
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+
   react@19.2.5: {}
 
   readable-stream@3.6.2:
@@ -5338,6 +5381,8 @@ snapshots:
       send: 0.19.2
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/tests/e2e/foundation.spec.ts
+++ b/tests/e2e/foundation.spec.ts
@@ -23,6 +23,7 @@ async function login(page: Page, account = accounts[0]) {
   await page.getByRole("button", { name: "Sign in", exact: true }).click();
   await expect(page.locator(".topbar .eyebrow")).toHaveText(account.displayName);
   await expect(page.getByRole("heading", { name: "Personal Workspace" })).toBeVisible();
+  await expect(page).toHaveURL(/\/studio$/);
 }
 
 async function signOut(page: Page) {
@@ -50,6 +51,33 @@ async function addVirtualAuthenticator(page: Page) {
   });
 }
 
+async function openStudio(page: Page) {
+  await openWorkspaceRoute(page, "/studio", "Studio");
+}
+
+async function openSkills(page: Page) {
+  await openWorkspaceRoute(page, "/skills", "Skills");
+}
+
+async function openProviders(page: Page) {
+  await openWorkspaceRoute(page, "/providers", "Providers");
+}
+
+async function openMembers(page: Page) {
+  await openWorkspaceRoute(page, "/members", "Members");
+}
+
+async function openSettings(page: Page) {
+  await openWorkspaceRoute(page, "/settings", "Settings");
+}
+
+async function openWorkspaceRoute(page: Page, path: string, label: string) {
+  const link = page.getByRole("link", { name: label });
+  await link.click();
+  await expect(page).toHaveURL(new RegExp(`${path}$`));
+  await expect(link).toHaveAttribute("aria-current", "page");
+}
+
 test.describe("foundation workspace flows", () => {
   test("allows all five configured test accounts to log in", async ({ page }) => {
     for (const account of accounts) {
@@ -71,33 +99,31 @@ test.describe("foundation workspace flows", () => {
     await expect(page.getByRole("button", { name: "Sign in", exact: true })).toBeVisible();
   });
 
-  test("navigates workspace panels from sidebar actions", async ({ page }) => {
+  test("routes workspace sections from sidebar actions", async ({ page }) => {
     await resetBrowserState(page);
     await login(page);
 
-    const providersNav = page.getByRole("button", { name: "Providers" });
-    await providersNav.click();
-    await expect(providersNav).toHaveAttribute("aria-current", "location");
-    await expect(page.locator("#providers-panel")).toBeFocused();
+    await openProviders(page);
+    await expect(page.getByRole("heading", { name: "Provider Profiles" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Agent Skills" })).toHaveCount(0);
 
     await page.getByRole("button", { name: "Add Provider" }).click();
     await expect(page.getByLabel("Provider name")).toBeFocused();
     await expect(page.getByLabel("Provider name")).toHaveValue("Local OpenAI Compatible");
 
-    const skillsNav = page.getByRole("button", { name: "Skills" });
-    await skillsNav.click();
-    await expect(skillsNav).toHaveAttribute("aria-current", "location");
-    await expect(page.locator("#skills-panel")).toBeFocused();
+    await openSkills(page);
+    await expect(page.getByRole("heading", { name: "Agent Skills" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Provider Profiles" })).toHaveCount(0);
 
-    const membersNav = page.getByRole("button", { name: "Members" });
-    await membersNav.click();
-    await expect(membersNav).toHaveAttribute("aria-current", "location");
-    await expect(page.locator("#members-panel")).toBeFocused();
+    await openMembers(page);
+    await expect(page.getByRole("heading", { name: "Workspace Access" })).toBeVisible();
 
-    const settingsNav = page.getByRole("button", { name: "Settings" });
-    await settingsNav.click();
-    await expect(settingsNav).toHaveAttribute("aria-current", "location");
-    await expect(page.locator("#settings-panel")).toBeFocused();
+    await openSettings(page);
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+
+    await page.goto("/providers");
+    await expect(page.getByRole("heading", { name: "Provider Profiles" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Providers" })).toHaveAttribute("aria-current", "page");
   });
 
   test("does not leak cached workspace data when switching users", async ({ page }) => {
@@ -131,6 +157,7 @@ test.describe("foundation workspace flows", () => {
     await resetBrowserState(page);
     await login(page);
 
+    await openSettings(page);
     await page.getByRole("button", { name: "Register Passkey" }).click();
     await expect(page.getByText("Passkey registered")).toBeVisible();
     await page.getByRole("button", { name: "Sign out" }).click();
@@ -146,6 +173,7 @@ test.describe("foundation workspace flows", () => {
     await signOut(page);
     await login(page, accounts[0]);
 
+    await openMembers(page);
     await page.getByLabel("Member email").fill(accounts[1].email);
     await page.getByLabel("New member role").selectOption("member");
     await page.getByRole("button", { name: "Add Member" }).click();
@@ -155,6 +183,7 @@ test.describe("foundation workspace flows", () => {
 
     await signOut(page);
     await login(page, accounts[1]);
+    await openMembers(page);
     await page.getByLabel("Active workspace").selectOption(ownerWorkspaceId);
     await expect(page.getByRole("heading", { name: "Personal Workspace" })).toBeVisible();
     await expect(page.locator(".member-item").filter({ hasText: accounts[0].displayName })).toBeVisible();
@@ -165,6 +194,7 @@ test.describe("foundation workspace flows", () => {
 
     await signOut(page);
     await login(page, accounts[0]);
+    await openMembers(page);
     await page.getByLabel(`Role for ${accounts[1].displayName}`).selectOption("viewer");
     await expect(page.getByLabel(`Role for ${accounts[1].displayName}`)).toHaveValue("viewer");
     await page.locator(".member-item").filter({ hasText: accounts[1].displayName }).getByRole("button", { name: "Remove" }).click();
@@ -172,6 +202,7 @@ test.describe("foundation workspace flows", () => {
 
     await signOut(page);
     await login(page, accounts[1]);
+    await openMembers(page);
     await expect(page.locator(".member-item").filter({ hasText: accounts[0].displayName })).toHaveCount(0);
   });
 
@@ -191,6 +222,7 @@ description: First workspace skill.
 
 # First Workspace Skill
 `);
+    await openStudio(page);
     await page.getByLabel("Generation provider").selectOption({ label: "First Workspace Provider" });
     await page.getByLabel("Generation skill").selectOption({ label: "first-workspace-skill" });
 
@@ -237,6 +269,7 @@ description: Scoped job skill.
 
 # Scoped Job Skill
 `);
+      await openStudio(page);
       await page.getByLabel("Generation provider").selectOption({ label: "Scoped Job Provider" });
       await page.getByLabel("Generation skill").selectOption({ label: "scoped-job-skill" });
       await page.getByLabel("Image prompt").fill("Workspace A generated prompt.");
@@ -277,6 +310,7 @@ description: Scoped job skill.
   test("creates a workspace provider profile without rendering the API key", async ({ page }) => {
     await login(page);
 
+    await openProviders(page);
     await page.getByLabel("Provider name").fill("Workspace Image Provider");
     await page.getByLabel("Base URL").fill("https://models.example.test/v1");
     await page.getByLabel("Default model").fill("gpt-image-workspace");
@@ -312,6 +346,7 @@ description: Skill for updated provider profile.
 # Editable Provider Skill
 `);
 
+      await openProviders(page);
       const providerRow = page.locator(".table-row").filter({ hasText: "Editable Provider" });
       await providerRow.getByRole("button", { name: "Edit" }).click();
       await page.getByLabel("Provider name").fill("Updated Provider");
@@ -326,6 +361,7 @@ description: Skill for updated provider profile.
       await expect(page.getByText("updated-secret-key")).toHaveCount(0);
 
       const prompt = `Use the updated provider ${Date.now()}.`;
+      await openStudio(page);
       await page.getByLabel("Generation provider").selectOption({ label: "Updated Provider" });
       await page.getByLabel("Generation skill").selectOption({ label: "editable-provider-skill" });
       await page.getByLabel("Image prompt").fill(prompt);
@@ -337,6 +373,7 @@ description: Skill for updated provider profile.
         { type: "image_generation", model: "updated-image-model", action: "generate" }
       ]);
 
+      await openProviders(page);
       await page.locator(".table-row").filter({ hasText: "Updated Provider" }).getByRole("button", { name: "Edit" }).click();
       await page.getByLabel("Provider name").fill("Updated Provider No Key Rotation");
       await page.getByLabel("Default model").fill("second-text-model");
@@ -346,6 +383,7 @@ description: Skill for updated provider profile.
       await expect(page.locator(".table-row").filter({ hasText: "Updated Provider No Key Rotation" })).toBeVisible();
 
       const secondPrompt = `Keep the existing provider key ${Date.now()}.`;
+      await openStudio(page);
       await page.getByLabel("Generation provider").selectOption({ label: "Updated Provider No Key Rotation" });
       await page.getByLabel("Generation skill").selectOption({ label: "editable-provider-skill" });
       await page.getByLabel("Image prompt").fill(secondPrompt);
@@ -357,9 +395,11 @@ description: Skill for updated provider profile.
         { type: "image_generation", model: "second-image-model", action: "generate" }
       ]);
 
+      await openProviders(page);
       await page.locator(".table-row").filter({ hasText: "Updated Provider" }).getByRole("button", { name: "Edit" }).click();
       await page.getByRole("button", { name: "Delete Provider" }).click();
       await expect(page.locator(".table-row").filter({ hasText: "Updated Provider No Key Rotation" })).toHaveCount(0);
+      await openStudio(page);
       await expect(page.getByLabel("Generation provider")).toHaveValue("");
     } finally {
       await mock.close();
@@ -377,6 +417,7 @@ description: Skill for updated provider profile.
       model: "viewer-protected-model",
       apiKey: "viewer-protected-key"
     });
+    await openMembers(page);
     await page.getByLabel("Member email").fill(accounts[1].email);
     await page.getByLabel("New member role").selectOption("viewer");
     await page.getByRole("button", { name: "Add Member" }).click();
@@ -384,6 +425,7 @@ description: Skill for updated provider profile.
 
     await signOut(page);
     await login(page, accounts[1]);
+    await openProviders(page);
     await page.getByLabel("Active workspace").selectOption(ownerWorkspaceId);
     await expect(page.locator(".table-row").filter({ hasText: "Viewer Protected Provider" })).toBeVisible();
     await page.locator(".table-row").filter({ hasText: "Viewer Protected Provider" }).getByRole("button", { name: "Edit" }).click();
@@ -397,6 +439,7 @@ description: Skill for updated provider profile.
 
   test("indexes a valid Agent Skill from an uploaded Skill file", async ({ page }) => {
     await login(page);
+    await openSkills(page);
     const filePath = await writeSkillFile("valid-skill.md", `---
 name: e2e-image-skill
 description: Generates images for the Playwright flow.
@@ -426,6 +469,7 @@ version: 1.0.0
 
 # Viewer Readable Skill
 `);
+    await openMembers(page);
     await page.getByLabel("Member email").fill(accounts[1].email);
     await page.getByLabel("New member role").selectOption("viewer");
     await page.getByRole("button", { name: "Add Member" }).click();
@@ -433,6 +477,7 @@ version: 1.0.0
 
     await signOut(page);
     await login(page, accounts[1]);
+    await openSkills(page);
     await page.getByLabel("Active workspace").selectOption(ownerWorkspaceId);
     await expect(page.locator(".skill-item").filter({ hasText: "viewer-readable-skill" })).toBeVisible();
 
@@ -482,6 +527,7 @@ Always render a polished packaged skill image.
         "zipped-image-skill/references/Scripts/unsafe.md": "This nested script text must not enter the prompt."
       });
 
+      await openSkills(page);
       await page.getByLabel("Skill file").setInputFiles(zipPath);
       await page.getByRole("button", { name: "Upload Skill" }).click();
       await expect(page.getByText("Indexed zipped-image-skill")).toBeVisible();
@@ -490,6 +536,7 @@ Always render a polished packaged skill image.
       await expectStoredSkillDirectory(zipPath, zippedSkillMd);
 
       const prompt = `Use the zipped package instructions ${Date.now()}.`;
+      await openStudio(page);
       await page.getByLabel("Generation provider").selectOption({ label: "Zip Skill Provider" });
       await page.getByLabel("Generation skill").selectOption({ label: "zipped-image-skill" });
       await page.getByLabel("Image prompt").fill(prompt);
@@ -517,6 +564,7 @@ Always render a polished packaged skill image.
 
   test("shows validation errors for an invalid Agent Skill file", async ({ page }) => {
     await login(page);
+    await openSkills(page);
     const filePath = await writeSkillFile("invalid-skill.md", "# No frontmatter here");
 
     await page.getByLabel("Skill file").setInputFiles(filePath);
@@ -697,10 +745,12 @@ description: Drives the mock generation request.
 
 Always produce a sharp product image.
 `);
+      await openSkills(page);
       await page.getByLabel("Skill file").setInputFiles(skillPath);
       await page.getByRole("button", { name: "Upload Skill" }).click();
       await expect(page.getByText("Indexed mock-generation-skill")).toBeVisible();
 
+      await openStudio(page);
       await page.getByLabel("Generation provider").selectOption({ label: "Generation Mock Provider" });
       await page.getByLabel("Generation skill").selectOption({ label: "mock-generation-skill" });
       const prompt = `Create a chrome object on a neutral background ${Date.now()}.`;
@@ -751,10 +801,12 @@ description: Drives the mock failed generation request.
 
 # Mock Failure Skill
 `);
+      await openSkills(page);
       await page.getByLabel("Skill file").setInputFiles(skillPath);
       await page.getByRole("button", { name: "Upload Skill" }).click();
       await expect(page.getByText("Indexed mock-failure-skill")).toBeVisible();
 
+      await openStudio(page);
       await page.getByLabel("Generation provider").selectOption({ label: "Failing Mock Provider" });
       await page.getByLabel("Generation skill").selectOption({ label: "mock-failure-skill" });
       await page.getByLabel("Image prompt").fill("This request should fail.");
@@ -800,6 +852,7 @@ description: Valid skill without provider permissions.
       });
       expect(upload.data?.uploadSkill.skill.id).toBeTruthy();
       await page.reload();
+      await openStudio(page);
       await expect(page.getByLabel("Generation skill").locator("option", { hasText: "no-permissions-skill" })).toHaveCount(1);
 
       await page.getByLabel("Generation provider").selectOption({ label: "Permission Mock Provider" });
@@ -840,6 +893,7 @@ description: Viewer block skill.
 # Viewer Block Skill
 `);
       const historyPrompt = `Viewer readable history prompt ${Date.now()}.`;
+      await openStudio(page);
       await page.getByLabel("Generation provider").selectOption({ label: "Viewer Block Provider" });
       await page.getByLabel("Generation skill").selectOption({ label: "viewer-block-skill" });
       await page.getByLabel("Image prompt").fill(historyPrompt);
@@ -849,6 +903,7 @@ description: Viewer block skill.
       const ownerImage = page.getByAltText("generated-image generated image").first();
       await expect(ownerImage).toBeVisible();
       const ownerAssetUrl = await elementImageSrc(ownerImage);
+      await openMembers(page);
       await page.getByLabel("Member email").fill(accounts[1].email);
       await page.getByLabel("New member role").selectOption("viewer");
       await page.getByRole("button", { name: "Add Member" }).click();
@@ -856,6 +911,7 @@ description: Viewer block skill.
 
       await signOut(page);
       await login(page, accounts[1]);
+      await openStudio(page);
       await page.getByLabel("Active workspace").selectOption(ownerWorkspaceId);
       await expect(page.getByLabel("Generation history")).toContainText(historyPrompt);
       await expect(page.getByLabel("Generation history")).toContainText("generated-image - image/png");
@@ -905,12 +961,14 @@ description: Shared history skill.
 
 # Shared History Skill
 `);
+      await openMembers(page);
       await page.getByLabel("Member email").fill(accounts[2].email);
       await page.getByLabel("New member role").selectOption("member");
       await page.getByRole("button", { name: "Add Member" }).click();
       const ownerWorkspaceId = await currentWorkspaceId(page);
       const prompt = `Collaborative history prompt ${Date.now()}.`;
 
+      await openStudio(page);
       await page.getByLabel("Generation provider").selectOption({ label: "Shared History Provider" });
       await page.getByLabel("Generation skill").selectOption({ label: "shared-history-skill" });
       await page.getByLabel("Image prompt").fill(prompt);
@@ -920,6 +978,7 @@ description: Shared history skill.
 
       await signOut(page);
       await login(page, accounts[2]);
+      await openStudio(page);
       await page.getByLabel("Active workspace").selectOption(ownerWorkspaceId);
 
       await expect(page.getByLabel("Generation history")).toContainText(prompt);
@@ -949,10 +1008,12 @@ description: Valid skill for capability rejection.
 
 # Capability Skill
 `);
+      await openSkills(page);
       await page.getByLabel("Skill file").setInputFiles(skillPath);
       await page.getByRole("button", { name: "Upload Skill" }).click();
       await expect(page.getByText("Indexed capability-skill")).toBeVisible();
 
+      await openStudio(page);
       await page.getByLabel("Generation provider").selectOption({ label: "No Capability Provider" });
       await page.getByLabel("Generation skill").selectOption({ label: "capability-skill" });
       await page.getByLabel("Image prompt").fill("This request should be blocked by provider capabilities.");
@@ -982,10 +1043,12 @@ description: Valid skill for non-image rejection.
 
 # Non Image Skill
 `);
+      await openSkills(page);
       await page.getByLabel("Skill file").setInputFiles(skillPath);
       await page.getByRole("button", { name: "Upload Skill" }).click();
       await expect(page.getByText("Indexed non-image-skill")).toBeVisible();
 
+      await openStudio(page);
       await page.getByLabel("Generation provider").selectOption({ label: "Non Image Mock Provider" });
       await page.getByLabel("Generation skill").selectOption({ label: "non-image-skill" });
       await page.getByLabel("Image prompt").fill("This request should fail after upstream.");
@@ -1121,10 +1184,16 @@ async function activeWorkspaceId(page: Page): Promise<string> {
 async function uploadSkillFromUi(page: Page, fileName: string, content: string): Promise<void> {
   const filePath = await writeSkillFile(fileName, content);
   const skillName = content.match(/^name:\s*(.+)$/m)?.[1]?.trim();
+  const previousPath = new URL(page.url()).pathname;
+  await page.goto("/skills");
+  await expect(page.getByRole("heading", { name: "Agent Skills" })).toBeVisible();
   await page.getByLabel("Skill file").setInputFiles(filePath);
   await page.getByRole("button", { name: "Upload Skill" }).click();
   if (skillName) {
     await expect(page.getByText(`Indexed ${skillName}`)).toBeVisible();
+  }
+  if (previousPath !== "/skills") {
+    await page.goto(previousPath);
   }
 }
 


### PR DESCRIPTION
## Summary

- Implements the scope captured in #33: Route workspace sections into separate studio pages.
- Adds `react-router-dom` and wraps the Vite app in `BrowserRouter`.
- Converts sidebar navigation to route links for `/studio`, `/skills`, `/providers`, `/members`, and `/settings`.
- Renders each workspace section only on its matching route while keeping shared workspace data in the shell.
- Updates Playwright flows to navigate routes explicitly and verifies direct `/providers` behavior.

## Linked Issue

Closes #33

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gen-image-studio/issues/33#issuecomment-4357568265

## Validation

- [x] `pnpm typecheck` via `rtk proxy pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm test:e2e` (26 passed)
- [x] `react-doctor --diff` via repo-local npm cache: 97/100, existing App-size/state warnings remain